### PR TITLE
fix sign error

### DIFF
--- a/custom_components/meross_lan/__init__.py
+++ b/custom_components/meross_lan/__init__.py
@@ -36,7 +36,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         # Listen to a message on MQTT.
         @callback
         async def message_received(msg):
-            _LOGGER.debug(msg)
             device_id = msg.topic.split("/")[2]
             mqttpayload = json.loads(msg.payload)
             header = mqttpayload.get("header")

--- a/custom_components/meross_lan/const.py
+++ b/custom_components/meross_lan/const.py
@@ -7,6 +7,7 @@ PLATFORMS = ["switch"]
 
 CONF_DEVICE_ID = "device_id"
 CONF_DISCOVERY_PAYLOAD = "payload"
+CONF_CREDENTIALS = "credentials"
 #DEFAULT_DEVICE_ID = "1909182170548290802048e1e9522946"
 
 DISCOVERY_TOPIC = "/appliance/+/publish"


### PR DESCRIPTION
Fix the problem that the following devices cannot be configured due to an error when sending MQTT messages.

- Device : mss110 us mt7682 (hardware:2.0.0 firmware:2.1.19) 
- Error : "payload":{"error":{"code":5001,"detail":"sign error"}}

If this does not set the sign parameter correctly when sending an MQTT message, the device will not accept the request. The calculation method of the sign parameter is unknown, but it seems that it can be reused to some extent. See the following link.

- https://github.com/donavanbecker/homebridge-meross/issues/20#issuecomment-615852271

Therefore, by saving and reusing the credentials obtained from the MQTT announcement, you will be able to configure and use your device.