### PR TITLE
Fix Rush

### DIFF
--- a/custom_components/meross_lan/devices/mts100.py
+++ b/custom_components/meross_lan/devices/mts100.py
@@ -9,21 +9,19 @@ from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE, CURRENT_HVAC_OFF,
     HVAC_MODE_AUTO, HVAC_MODE_HEAT, HVAC_MODE_OFF,
 )
-
 from homeassistant.components.number import (
     DOMAIN as PLATFORM_NUMBER,
     NumberEntity,
 )
-from homeassistant.components.number.const import (
-    MODE_BOX,
-)
 from homeassistant.const import (
     DEVICE_CLASS_TEMPERATURE,
     TEMP_CELSIUS,
-    ENTITY_CATEGORY_CONFIG,
 )
 
-from ..meross_entity import _MerossEntity
+from ..meross_entity import (
+    _MerossEntity,
+    ENTITY_CATEGORY_CONFIG,
+)
 from ..merossclient import const as mc  # mEROSS cONST
 
 
@@ -274,10 +272,6 @@ class Mts100SetPointNumber(_MerossEntity, NumberEntity):
     @property
     def name(self) -> str:
         return f"{self.subdevice.name} - {self._preset_mode} {DEVICE_CLASS_TEMPERATURE}"
-
-    @property
-    def mode(self) -> str:
-        return MODE_BOX
 
     @property
     def step(self) -> float:

--- a/custom_components/meross_lan/light.py
+++ b/custom_components/meross_lan/light.py
@@ -37,14 +37,15 @@ except:
 
 
 import homeassistant.util.color as color_util
-from homeassistant.const import (
-    STATE_ON, STATE_OFF,
-    ENTITY_CATEGORY_CONFIG,
-)
 
 from .merossclient import const as mc
 from .meross_device import MerossDevice
-from .meross_entity import _MerossToggle, platform_setup_entry, platform_unload_entry
+from .meross_entity import (
+    _MerossToggle,
+    platform_setup_entry, platform_unload_entry,
+    STATE_ON, STATE_OFF,
+    ENTITY_CATEGORY_CONFIG,
+)
 from .const import DND_ID
 
 """

--- a/custom_components/meross_lan/manifest.json
+++ b/custom_components/meross_lan/manifest.json
@@ -13,5 +13,5 @@
   "dependencies": [],
   "after_dependencies": ["mqtt", "dhcp"],
   "codeowners": ["@krahabb"],
-  "version": "2.4.1"
+  "version": "2.4.2"
 }

--- a/custom_components/meross_lan/meross_entity.py
+++ b/custom_components/meross_lan/meross_entity.py
@@ -3,6 +3,9 @@
 
  actual HA custom platform entities will be derived like this:
  MerossLanSwitch(_MerossToggle, SwitchEntity)
+
+ we also try to 'commonize' HA core symbols import in order to better manage
+ versioning
 """
 from __future__ import annotations
 
@@ -11,6 +14,10 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.const import (
     STATE_ON, STATE_OFF,
 )
+try:# 2021.11 new symbols
+    from homeassistant.const import ENTITY_CATEGORY_CONFIG
+except:
+    ENTITY_CATEGORY_CONFIG = 'config'
 
 
 from .merossclient import const as mc, get_productnameuuid

--- a/custom_components/meross_lan/number.py
+++ b/custom_components/meross_lan/number.py
@@ -8,12 +8,14 @@ from homeassistant.components.number.const import (
     DEFAULT_MIN_VALUE,
     DEFAULT_MAX_VALUE,
     DEFAULT_STEP,
-    MODE_BOX,
 )
-from homeassistant.const import ENTITY_CATEGORY_CONFIG
 
 from .merossclient import const as mc  # mEROSS cONST
-from .meross_entity import _MerossEntity, platform_setup_entry, platform_unload_entry
+from .meross_entity import (
+    _MerossEntity,
+    platform_setup_entry, platform_unload_entry,
+    ENTITY_CATEGORY_CONFIG,
+)
 
 
 async def async_setup_entry(hass: object, config_entry: object, async_add_devices):
@@ -100,9 +102,6 @@ class MerossLanHubAdjustNumber(MerossLanNumber):
     def name(self) -> str:
         return f"{self.subdevice.name} - adjust {self._label} {self._attr_device_class}"
 
-    @property
-    def mode(self) -> str:
-        return MODE_BOX
 
     async def async_set_value(self, value: float) -> None:
 

--- a/custom_components/meross_lan/switch.py
+++ b/custom_components/meross_lan/switch.py
@@ -5,13 +5,14 @@ from homeassistant.components.switch import (
     SwitchEntity,
     DEVICE_CLASS_OUTLET
 )
-from homeassistant.const import (
+
+from .merossclient import const as mc  # mEROSS cONST
+from .meross_entity import (
+    _MerossToggle,
+    platform_setup_entry, platform_unload_entry,
     STATE_OFF, STATE_ON,
     ENTITY_CATEGORY_CONFIG,
 )
-
-from .merossclient import const as mc  # mEROSS cONST
-from .meross_entity import _MerossToggle, platform_setup_entry, platform_unload_entry
 from .const import DND_ID
 
 


### PR DESCRIPTION
- fix fatal incompatibility on HA cores older than 2021.11 (#121) - now succesfully tested down to 2021.4.0
- delete bindings and entities from unpaired/removed smart hub subdevices (try to fix #119)
- refine the timestamp syncing feature and try to avoid unneded 'device timestamp error logs' (#98)