### PR TITLE
Release Keep

### DIFF
--- a/custom_components/meross_lan/climate.py
+++ b/custom_components/meross_lan/climate.py
@@ -4,11 +4,26 @@ from homeassistant.components.climate import (
     DOMAIN as PLATFORM_CLIMATE,
     ClimateEntity,
 )
-from homeassistant.components.climate.const import (
-    PRESET_AWAY, PRESET_COMFORT, PRESET_SLEEP, SUPPORT_PRESET_MODE, SUPPORT_TARGET_TEMPERATURE,
-    CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE, CURRENT_HVAC_OFF,
-    HVAC_MODE_AUTO, HVAC_MODE_HEAT, HVAC_MODE_OFF,
-)
+try:
+    from homeassistant.components.climate.const import (
+        ClimateEntityFeature, HVACMode, HVACAction,
+        PRESET_AWAY, PRESET_COMFORT, PRESET_SLEEP,
+    )
+    SUPPORT_PRESET_MODE = ClimateEntityFeature.PRESET_MODE
+    SUPPORT_TARGET_TEMPERATURE = ClimateEntityFeature.TARGET_TEMPERATURE
+    HVAC_MODE_AUTO = HVACMode.AUTO
+    HVAC_MODE_HEAT = HVACMode.HEAT
+    HVAC_MODE_OFF = HVACMode.OFF
+    CURRENT_HVAC_HEAT = HVACAction.HEATING
+    CURRENT_HVAC_IDLE = HVACAction.IDLE
+    CURRENT_HVAC_OFF = HVACAction.OFF
+except:# fallback (pre 2022.5)
+    from homeassistant.components.climate.const import (
+        PRESET_AWAY, PRESET_COMFORT, PRESET_SLEEP, SUPPORT_PRESET_MODE, SUPPORT_TARGET_TEMPERATURE,
+        CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE, CURRENT_HVAC_OFF,
+        HVAC_MODE_AUTO, HVAC_MODE_HEAT, HVAC_MODE_OFF,
+    )
+
 from homeassistant.const import (
     TEMP_CELSIUS,
     ATTR_TEMPERATURE,

--- a/custom_components/meross_lan/climate.py
+++ b/custom_components/meross_lan/climate.py
@@ -182,6 +182,8 @@ class MtsSetPointNumber(MLConfigNumber):
     Helper entity to configure MTS (thermostats) setpoints
     AKA: Heat(comfort) - Cool(sleep) - Eco(away)
     """
+    multiplier = 10
+
     PRESET_TO_ICON_MAP = {
         PRESET_COMFORT: 'mdi:sun-thermometer',
         PRESET_SLEEP: 'mdi:power-sleep',
@@ -202,18 +204,22 @@ class MtsSetPointNumber(MLConfigNumber):
         )
 
     @property
-    def name(self) -> str:
+    def name(self):
         return f"{self._climate.name} - {self._preset_mode} {DEVICE_CLASS_TEMPERATURE}"
 
     @property
-    def step(self) -> float:
-        return self._climate._attr_target_temperature_step
+    def native_max_value(self):
+        return self._climate._attr_max_temp
 
     @property
-    def min_value(self) -> float:
+    def native_min_value(self):
         return self._climate._attr_min_temp
 
     @property
-    def max_value(self) -> float:
-        return self._climate._attr_max_temp
+    def native_step(self):
+        return self._climate._attr_target_temperature_step
+
+    @property
+    def native_unit_of_measurement(self):
+        return TEMP_CELSIUS
 

--- a/custom_components/meross_lan/config_flow.py
+++ b/custom_components/meross_lan/config_flow.py
@@ -90,7 +90,7 @@ class CloudKeyMixin:
                 _err = e.reason
             except Exception as e:
                 errors[CONF_ERROR] = ERR_CANNOT_CONNECT
-                _err = str(e)
+                _err = str(e) or type(e).__name__
             return self.async_show_form(
                 step_id="cloudkey",
                 data_schema=vol.Schema({

--- a/custom_components/meross_lan/const.py
+++ b/custom_components/meross_lan/const.py
@@ -44,6 +44,7 @@ CONF_TIMESTAMP = mc.KEY_TIMESTAMP # this is a 'fake' conf param we'll add to con
 """
 PARAM_UNAVAILABILITY_TIMEOUT = 20  # number of seconds since last inquiry to consider the device unavailable
 PARAM_HEARTBEAT_PERIOD = 295 # whatever the connection state periodically inquire the device is there
+PARAM_RESTORESTATE_TIMEOUT = 300 # used when restoring 'calculated' state after HA restart
 PARAM_ENERGY_UPDATE_PERIOD = 55 # read energy consumption only every ... second
 PARAM_SIGNAL_UPDATE_PERIOD = 295 # read energy consumption only every ... second
 PARAM_HUBBATTERY_UPDATE_PERIOD = 3595 # read battery levels only every ... second

--- a/custom_components/meross_lan/cover.py
+++ b/custom_components/meross_lan/cover.py
@@ -328,7 +328,7 @@ class MLGarageConfigSwitch(MLConfigSwitch):
 
     def __init__(self, device, key: str):
         self._key = key
-        super().__init__(device, None, f"config_{key}", None, None)
+        super().__init__(device, None, f"config_{key}", None, None, None)
 
 
     @property
@@ -467,18 +467,13 @@ class MLRollerShutter(_MerossEntity, CoverEntity):
         if last_state:
             _attr = last_state.attributes
             if EXTRA_ATTR_DURATION_OPEN in _attr:
-                # restore anyway besides PARAM_RESTORESTATE_TIMEOUT
-                # since this is no harm and unlikely to change
-                # better than defaulting to a pseudo-random (30000) value
                 self._signalOpen = _attr[EXTRA_ATTR_DURATION_OPEN]
                 self._attr_extra_state_attributes[EXTRA_ATTR_DURATION_OPEN] = self._signalOpen
             if EXTRA_ATTR_DURATION_CLOSE in _attr:
                 self._signalClose = _attr[EXTRA_ATTR_DURATION_CLOSE]
                 self._attr_extra_state_attributes[EXTRA_ATTR_DURATION_CLOSE] = self._signalClose
             if ATTR_CURRENT_POSITION in _attr:
-                delta = _now.timestamp() - (last_state.last_updated or last_state.last_changed).timestamp()
-                if delta < PARAM_RESTORESTATE_TIMEOUT:
-                    self._position_timed = _attr[ATTR_CURRENT_POSITION]
+                self._position_timed = _attr[ATTR_CURRENT_POSITION]
         #await super().async_added_to_hass() super is empty..dont call
 
 

--- a/custom_components/meross_lan/cover.py
+++ b/custom_components/meross_lan/cover.py
@@ -6,11 +6,24 @@ from logging import DEBUG, INFO, WARNING
 from homeassistant.components.cover import (
     DOMAIN as PLATFORM_COVER,
     CoverEntity,
-    DEVICE_CLASS_GARAGE, DEVICE_CLASS_SHUTTER,
     ATTR_POSITION, ATTR_CURRENT_POSITION,
-    SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_SET_POSITION, SUPPORT_STOP,
     STATE_OPEN, STATE_OPENING, STATE_CLOSED, STATE_CLOSING
 )
+try:
+    from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
+    DEVICE_CLASS_GARAGE = CoverDeviceClass.GARAGE
+    DEVICE_CLASS_SHUTTER = CoverDeviceClass.SHUTTER
+    SUPPORT_OPEN = CoverEntityFeature.OPEN
+    SUPPORT_CLOSE = CoverEntityFeature.CLOSE
+    SUPPORT_SET_POSITION = CoverEntityFeature.SET_POSITION
+    SUPPORT_STOP = CoverEntityFeature.STOP
+except:# fallback (pre 2022.5)
+    from homeassistant.components.cover import (
+        DEVICE_CLASS_GARAGE, DEVICE_CLASS_SHUTTER,
+        SUPPORT_OPEN, SUPPORT_CLOSE,
+        SUPPORT_SET_POSITION, SUPPORT_STOP,
+    )
+
 from homeassistant.const import (
     TIME_SECONDS,
 )

--- a/custom_components/meross_lan/devices/mod100.py
+++ b/custom_components/meross_lan/devices/mod100.py
@@ -35,6 +35,7 @@ class MLDiffuserLight(MLLightBase):
             payload.get(mc.KEY_CHANNEL, 0),
             None,
             None,
+            None,
             None)
         """
         self._light = {

--- a/custom_components/meross_lan/devices/mts100.py
+++ b/custom_components/meross_lan/devices/mts100.py
@@ -111,7 +111,7 @@ class Mts100SetPointNumber(MtsSetPointNumber):
     """
     customize MtsSetPointNumber to interact with Mts100 family valves
     """
-    async def async_set_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float):
         self.device.request(
             mc.NS_APPLIANCE_HUB_MTS100_TEMPERATURE,
             mc.METHOD_SET,
@@ -119,7 +119,7 @@ class Mts100SetPointNumber(MtsSetPointNumber):
                 mc.KEY_TEMPERATURE: [
                     {
                         mc.KEY_ID: self.subdevice.id,
-                        self._key: int(value * 10)
+                        self._key: int(value * self.multiplier)
                     }
                 ]
             },

--- a/custom_components/meross_lan/devices/mts200.py
+++ b/custom_components/meross_lan/devices/mts200.py
@@ -143,11 +143,11 @@ class Mts200Climate(MtsClimate):
         if isinstance(_t := payload.get(mc.KEY_MAX), int):
             self._attr_max_temp = _t / 10
         if isinstance(_t := payload.get(mc.KEY_HEATTEMP), int):
-            self.number_comfort_temperature.update_state(_t / 10)
+            self.number_comfort_temperature.update_native_value(_t)
         if isinstance(_t := payload.get(mc.KEY_COOLTEMP), int):
-            self.number_sleep_temperature.update_state(_t / 10)
+            self.number_sleep_temperature.update_native_value(_t)
         if isinstance(_t := payload.get(mc.KEY_ECOTEMP), int):
-            self.number_away_temperature.update_state(_t / 10)
+            self.number_away_temperature.update_native_value(_t)
         self.update_modes()
 
 
@@ -161,11 +161,11 @@ class Mts200SetPointNumber(MtsSetPointNumber):
     """
     customize MtsSetPointNumber to interact with Mts200 family valves
     """
-    async def async_set_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float):
         self.device.request(
             mc.NS_APPLIANCE_CONTROL_THERMOSTAT_MODE,
             mc.METHOD_SET,
-            {mc.KEY_MODE: [{mc.KEY_CHANNEL: self.channel, self._key: int(value * 10)}]} # the device rounds down ?!
+            {mc.KEY_MODE: [{mc.KEY_CHANNEL: self.channel, self._key: int(value * self.multiplier)}]} # the device rounds down ?!
         )
 
 

--- a/custom_components/meross_lan/helpers.py
+++ b/custom_components/meross_lan/helpers.py
@@ -2,31 +2,36 @@
     Helpers!
 """
 import logging
+from functools import partial
 from time import time
+from homeassistant.util.dt import utcnow
 
 from .merossclient import const as mc
 
 LOGGER = logging.getLogger(__name__[:-8]) #get base custom_component name for logging
-_trap_dict = dict()
+_TRAP_DICT = dict()
 
 def LOGGER_trap(level, timeout, msg, *args):
     """
     avoid repeating the same last log message until something changes or timeout expires
     used mainly when discovering new devices
     """
-    global _trap_dict
+    global _TRAP_DICT
 
     epoch = time()
     trap_key = (msg, *args)
-    trap_time = _trap_dict.get(trap_key, 0)
+    trap_time = _TRAP_DICT.get(trap_key, 0)
     if ((epoch - trap_time) < timeout):
         return
 
     LOGGER.log(level, msg, *args)
-    _trap_dict[trap_key] = epoch
+    _TRAP_DICT[trap_key] = epoch
 
 
 def clamp(_value, _min, _max):
+    """
+    saturate _value between _min and _max
+    """
     if _value >= _max:
         return _max
     elif _value <= _min:
@@ -35,12 +40,12 @@ def clamp(_value, _min, _max):
         return _value
 
 
-def reverse_lookup(map: dict, value):
+def reverse_lookup(_dict: dict, value):
     """
     lookup the values in map (dict) and return
     the corresponding key
     """
-    for _key, _value in map.items():
+    for _key, _value in _dict.items():
         if _value == value:
             return _key
     return None
@@ -114,3 +119,39 @@ def mqtt_publish(hass, topic, payload):
     are a bit too much to follow with a clean backward compatible code
     """
     hass.async_create_task(hass.data[DATA_MQTT].async_publish(topic, payload, 0, False))
+
+
+"""
+RECORDER helpers
+"""
+from homeassistant.components.recorder import history
+
+async def get_entity_last_state(hass, entity_id):
+    """
+    recover the last known good state from recorder in order to
+    restore transient state information when restarting HA
+    """
+    if hasattr(history, 'get_state'):# removed in 2022.6.x
+        return history.get_state(hass, utcnow(), entity_id)
+
+    elif hasattr(history, 'get_last_state_changes'):
+        """
+        get_instance too is relatively new: I hope it was in place when
+        get_last_state_changes was added
+        """
+        from homeassistant.components.recorder import get_instance
+        _last_state: dict = await get_instance(hass).async_add_executor_job(
+                partial(
+                    history.get_last_state_changes,
+                    hass,
+                    1,
+                    entity_id,
+                )
+            )
+        if entity_id in _last_state:
+            _last_state: list = _last_state[entity_id]
+            if _last_state:
+                return _last_state[0]
+
+
+    return None

--- a/custom_components/meross_lan/humidifier.py
+++ b/custom_components/meross_lan/humidifier.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 from functools import partial
 
-from homeassistant.components.humidifier import (
-    DOMAIN as PLATFORM_HUMIDIFIER,
-    DEVICE_CLASS_HUMIDIFIER,
-    HumidifierEntity
-)
-from homeassistant.components.humidifier.const import SUPPORT_MODES, MODE_ECO, MODE_NORMAL
+try:
+    from homeassistant.components.humidifier import (
+        DOMAIN as PLATFORM_HUMIDIFIER,
+        HumidifierDeviceClass,
+        HumidifierEntity,
+    )
+    from homeassistant.components.humidifier.const import (
+        HumidifierEntityFeature,
+        MODE_ECO, MODE_NORMAL,
+    )
+    DEVICE_CLASS_HUMIDIFIER = HumidifierDeviceClass.HUMIDIFIER
+    SUPPORT_MODES = HumidifierEntityFeature.MODES
+except:
+    from homeassistant.components.humidifier import (
+        DOMAIN as PLATFORM_HUMIDIFIER,
+        DEVICE_CLASS_HUMIDIFIER,
+        HumidifierEntity,
+    )
+    from homeassistant.components.humidifier.const import (
+        SUPPORT_MODES, MODE_ECO, MODE_NORMAL
+    )
+
 from homeassistant.const import STATE_OFF, STATE_ON
 
 from .merossclient import const as mc  # mEROSS cONST

--- a/custom_components/meross_lan/light.py
+++ b/custom_components/meross_lan/light.py
@@ -204,7 +204,7 @@ class MLLight(MLLightBase):
         # in case we're not using togglex fallback to toggle but..the light could
         # be switchable by 'onoff' field in light payload itself..(to be investigated)
         super().__init__(
-            device, channel, None, None,
+            device, channel, None, None, None,
             mc.NS_APPLIANCE_CONTROL_TOGGLEX if self._usetogglex else None)
         """
         self._light = {
@@ -369,7 +369,7 @@ class MLDNDLightEntity(_MerossToggle, LightEntity):
 
 
     def __init__(self, device: MerossDevice):
-        super().__init__(device, None, DND_ID, mc.KEY_DNDMODE, None)
+        super().__init__(device, None, DND_ID, mc.KEY_DNDMODE, None, None)
 
 
     @property

--- a/custom_components/meross_lan/light.py
+++ b/custom_components/meross_lan/light.py
@@ -12,12 +12,19 @@ from .helpers import reverse_lookup
 
 # back-forward compatibility hell
 try:
-    from homeassistant.components.light import (
-        SUPPORT_BRIGHTNESS,
-        SUPPORT_COLOR,
-        SUPPORT_COLOR_TEMP,
-        SUPPORT_EFFECT
-    )
+    try:
+        from homeassistant.components.light import LightEntityFeature
+        SUPPORT_BRIGHTNESS = 0
+        SUPPORT_COLOR = 0
+        SUPPORT_COLOR_TEMP = 0
+        SUPPORT_EFFECT = LightEntityFeature.EFFECT
+    except:
+        from homeassistant.components.light import (
+            SUPPORT_BRIGHTNESS,
+            SUPPORT_COLOR,
+            SUPPORT_COLOR_TEMP,
+            SUPPORT_EFFECT
+        )
 except:
     # should HA remove any we guess SUPPORT_EFFECT still valued at 4
     SUPPORT_BRIGHTNESS = 0
@@ -26,12 +33,21 @@ except:
     SUPPORT_EFFECT = 4
 
 try:
-    from homeassistant.components.light import (
-        COLOR_MODE_UNKNOWN, COLOR_MODE_ONOFF, COLOR_MODE_BRIGHTNESS,
-        COLOR_MODE_HS, COLOR_MODE_RGB, COLOR_MODE_COLOR_TEMP,
-    )
+    try:
+        from homeassistant.components.light import ColorMode
+        COLOR_MODE_UNKNOWN = ColorMode.UNKNOWN
+        COLOR_MODE_ONOFF = ColorMode.ONOFF
+        COLOR_MODE_BRIGHTNESS = ColorMode.BRIGHTNESS
+        COLOR_MODE_HS = ColorMode.HS
+        COLOR_MODE_RGB = ColorMode.RGB
+        COLOR_MODE_COLOR_TEMP = ColorMode.COLOR_TEMP
+    except:
+        from homeassistant.components.light import (
+            COLOR_MODE_UNKNOWN, COLOR_MODE_ONOFF, COLOR_MODE_BRIGHTNESS,
+            COLOR_MODE_HS, COLOR_MODE_RGB, COLOR_MODE_COLOR_TEMP,
+        )
 except:
-    COLOR_MODE_UNKNOWN = ''
+    COLOR_MODE_UNKNOWN = ''# leave empty so we don't use color_modes
     COLOR_MODE_ONOFF = COLOR_MODE_UNKNOWN
     COLOR_MODE_BRIGHTNESS = COLOR_MODE_UNKNOWN
     COLOR_MODE_HS = COLOR_MODE_UNKNOWN

--- a/custom_components/meross_lan/manifest.json
+++ b/custom_components/meross_lan/manifest.json
@@ -13,5 +13,5 @@
   "dependencies": [],
   "after_dependencies": ["mqtt", "dhcp"],
   "codeowners": ["@krahabb"],
-  "version": "2.6.0-alpha.2"
+  "version": "2.6.1"
 }

--- a/custom_components/meross_lan/manifest.json
+++ b/custom_components/meross_lan/manifest.json
@@ -13,5 +13,5 @@
   "dependencies": [],
   "after_dependencies": ["mqtt", "dhcp"],
   "codeowners": ["@krahabb"],
-  "version": "2.6.0-alpha.1"
+  "version": "2.6.0-alpha.2"
 }

--- a/custom_components/meross_lan/manifest.json
+++ b/custom_components/meross_lan/manifest.json
@@ -13,5 +13,5 @@
   "dependencies": [],
   "after_dependencies": ["mqtt", "dhcp"],
   "codeowners": ["@krahabb"],
-  "version": "2.5.7"
+  "version": "2.5.8"
 }

--- a/custom_components/meross_lan/manifest.json
+++ b/custom_components/meross_lan/manifest.json
@@ -13,5 +13,5 @@
   "dependencies": [],
   "after_dependencies": ["mqtt", "dhcp"],
   "codeowners": ["@krahabb"],
-  "version": "2.5.8"
+  "version": "2.6.0-alpha.0"
 }

--- a/custom_components/meross_lan/manifest.json
+++ b/custom_components/meross_lan/manifest.json
@@ -13,5 +13,5 @@
   "dependencies": [],
   "after_dependencies": ["mqtt", "dhcp"],
   "codeowners": ["@krahabb"],
-  "version": "2.6.0-alpha.0"
+  "version": "2.6.0-alpha.1"
 }

--- a/custom_components/meross_lan/media_player.py
+++ b/custom_components/meross_lan/media_player.py
@@ -5,13 +5,26 @@ from homeassistant.components.media_player import (
     DOMAIN as PLATFORM_MEDIA_PLAYER,
     MediaPlayerEntity, MediaPlayerDeviceClass,
 )
-from homeassistant.components.media_player.const import (
-    SUPPORT_TURN_ON, SUPPORT_TURN_OFF,
-    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP,
-    SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_STOP,
-    MEDIA_TYPE_MUSIC,
-)
+try:
+    from homeassistant.components.media_player.const import (
+        MEDIA_TYPE_MUSIC,
+        MediaPlayerEntityFeature,
+    )
+    SUPPORT_VOLUME_MUTE = MediaPlayerEntityFeature.VOLUME_MUTE
+    SUPPORT_VOLUME_SET = MediaPlayerEntityFeature.VOLUME_SET
+    SUPPORT_VOLUME_STEP = MediaPlayerEntityFeature.VOLUME_STEP
+    SUPPORT_NEXT_TRACK = MediaPlayerEntityFeature.NEXT_TRACK
+    SUPPORT_PREVIOUS_TRACK = MediaPlayerEntityFeature.PREVIOUS_TRACK
+    SUPPORT_PLAY = MediaPlayerEntityFeature.PLAY
+    SUPPORT_STOP = MediaPlayerEntityFeature.STOP
+except:# fallback (pre 2022.5)
+    from homeassistant.components.media_player.const import (
+        MEDIA_TYPE_MUSIC,
+        SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP,
+        SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK,
+        SUPPORT_PLAY, SUPPORT_STOP,
+    )
+    
 from homeassistant.const import (
     STATE_IDLE, STATE_OFF, STATE_PLAYING,
 )

--- a/custom_components/meross_lan/meross_device.py
+++ b/custom_components/meross_lan/meross_device.py
@@ -69,6 +69,7 @@ TRACE_ABILITY_EXCLUDE = (
     mc.NS_APPLIANCE_HUB_EXCEPTION, # disconnects
     mc.NS_APPLIANCE_HUB_REPORT, # disconnects
     mc.NS_APPLIANCE_HUB_SUBDEVICELIST, # disconnects
+    mc.NS_APPLIANCE_HUB_PAIRSUBDEV, # disconnects
     mc.NS_APPLIANCE_MCU_UPGRADE, # disconnects
     mc.NS_APPLIANCE_MCU_HP110_PREVIEW, # disconnects
     mc.NS_APPLIANCE_MCU_FIRMWARE, # disconnects

--- a/custom_components/meross_lan/meross_device_hub.py
+++ b/custom_components/meross_lan/meross_device_hub.py
@@ -384,7 +384,7 @@ class MerossSubDevice:
                 continue
             number:MLHubAdjustNumber
             if (number := getattr(self, f"number_adjust_{p_key}", None)) is not None:
-                number.update_value(p_value)
+                number.update_native_value(p_value)
 
 
     def _parse_togglex(self, p_togglex: dict) -> None:
@@ -489,11 +489,11 @@ class MTS100SubDevice(MerossSubDevice):
         climate.update_modes()
 
         if isinstance(_t := p_temperature.get(mc.KEY_COMFORT), int):
-            climate.number_comfort_temperature.update_state(_t / 10)
+            climate.number_comfort_temperature.update_native_value(_t)
         if isinstance(_t := p_temperature.get(mc.KEY_ECONOMY), int):
-            climate.number_sleep_temperature.update_state(_t / 10)
+            climate.number_sleep_temperature.update_native_value(_t)
         if isinstance(_t := p_temperature.get(mc.KEY_AWAY), int):
-            climate.number_away_temperature.update_state(_t / 10)
+            climate.number_away_temperature.update_native_value(_t)
 
         if mc.KEY_OPENWINDOW in p_temperature:
             self.binary_sensor_window.update_onoff(p_temperature[mc.KEY_OPENWINDOW])

--- a/custom_components/meross_lan/meross_device_hub.py
+++ b/custom_components/meross_lan/meross_device_hub.py
@@ -85,20 +85,18 @@ class MerossDeviceHub(MerossDevice):
 
     def _handle_Appliance_Hub_Sensor_All(self,
     namespace: str, method: str, payload: dict, header: dict):
-        self._lastupdate_sensor = self.lastupdate
-        self._subdevice_parse(payload, mc.KEY_ALL)
-        self.request_get(mc.NS_APPLIANCE_HUB_SENSOR_ADJUST)
+        if self._subdevice_parse(payload, mc.KEY_ALL):
+            self._lastupdate_sensor = self.lastupdate
+            self.request_get(mc.NS_APPLIANCE_HUB_SENSOR_ADJUST)
 
 
     def _handle_Appliance_Hub_Sensor_TempHum(self,
     namespace: str, method: str, payload: dict, header: dict):
-        self._lastupdate_sensor = self.lastupdate
         self._subdevice_parse(payload, mc.KEY_TEMPHUM)
 
 
     def _handle_Appliance_Hub_Sensor_Smoke(self,
     namespace: str, method: str, payload: dict, header: dict):
-        self._lastupdate_sensor = self.lastupdate
         self._subdevice_parse(payload, mc.KEY_SMOKEALARM)
 
 
@@ -112,9 +110,9 @@ class MerossDeviceHub(MerossDevice):
 
     def _handle_Appliance_Hub_Mts100_All(self,
     namespace: str, method: str, payload: dict, header: dict):
-        self._lastupdate_mts100 = self.lastupdate
-        self._subdevice_parse(payload, mc.KEY_ALL)
-        self.request_get(mc.NS_APPLIANCE_HUB_MTS100_ADJUST)
+        if self._subdevice_parse(payload, mc.KEY_ALL):
+            self._lastupdate_mts100 = self.lastupdate
+            self.request_get(mc.NS_APPLIANCE_HUB_MTS100_ADJUST)
 
 
     def _handle_Appliance_Hub_Mts100_Mode(self,
@@ -185,7 +183,8 @@ class MerossDeviceHub(MerossDevice):
         return deviceclass(self, p_subdevice)
 
 
-    def _subdevice_parse(self, payload: dict, key: str) -> None:
+    def _subdevice_parse(self, payload: dict, key: str) -> int:
+        count = 0
         if isinstance(p_subdevices := payload.get(key), list):
             for p_subdevice in p_subdevices:
                 p_id = p_subdevice.get(mc.KEY_ID)
@@ -201,7 +200,8 @@ class MerossDeviceHub(MerossDevice):
                     method = getattr(subdevice, f"_parse_{key}", None)
                     if method is not None:
                         method(p_subdevice)
-
+                        count += 1
+        return count
 
     def _parse_hub(self, p_hub: dict) -> None:
         """

--- a/custom_components/meross_lan/meross_entity.py
+++ b/custom_components/meross_lan/meross_entity.py
@@ -9,8 +9,6 @@
 """
 from __future__ import annotations
 
-from functools import partial
-
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers import device_registry as dr
 from homeassistant.const import (
@@ -198,8 +196,10 @@ class _MerossToggle(_MerossEntity):
         channel: object,
         entitykey: str,
         device_class: str,
-        namespace: str):
-        super().__init__(device, channel, entitykey, device_class)
+        subdevice: 'MerossSubDevice',
+        namespace: str,
+        ):
+        super().__init__(device, channel, entitykey, device_class, subdevice)
         self.namespace = namespace
         self.key = None if namespace is None else get_namespacekey(namespace)
 

--- a/custom_components/meross_lan/meross_entity.py
+++ b/custom_components/meross_lan/meross_entity.py
@@ -123,11 +123,6 @@ class _MerossEntity:
     def device_class(self) -> str | None:
         return self._attr_device_class
 
-    """ moved to sensor to comply with HA development
-    @property
-    def unit_of_measurement(self) -> str | None:
-        return self._attr_unit_of_measurement
-    """
 
     @property
     def should_poll(self) -> bool:
@@ -143,11 +138,12 @@ class _MerossEntity:
     def assumed_state(self) -> bool:
         return False
 
-
+    """
+    avoid overriding state since it is mostly declared final in HA platforms
     @property
     def state(self) -> StateType:
         return self._attr_state
-
+    """
 
     async def async_added_to_hass(self) -> None:
         return

--- a/custom_components/meross_lan/merossclient/__init__.py
+++ b/custom_components/meross_lan/merossclient/__init__.py
@@ -162,7 +162,7 @@ async def async_get_cloud_key(username, password, session: aiohttp.client.Client
     session = session or aiohttp.ClientSession()
     timestamp = int(time())
     nonce = uuid4().hex
-    params = '{"email": "'+username+'", "password": "'+password+'"}'
+    params = json_dumps({"email": username, "password": password})
     params = b64encode(params.encode('utf-8')).decode('ascii')
     sign = md5(("23x17ahWarFH6w29" + str(timestamp) + nonce + params).encode('utf-8')).hexdigest()
     with async_timeout.timeout(10):

--- a/custom_components/meross_lan/merossclient/__init__.py
+++ b/custom_components/meross_lan/merossclient/__init__.py
@@ -177,10 +177,20 @@ async def async_get_cloud_key(username, password, session: aiohttp.client.Client
         )
         response.raise_for_status()
     json: dict = await response.json()
-    key = json.get(mc.KEY_DATA, {}).get(mc.KEY_KEY)
-    if key is None:
-        raise MerossApiError(json[mc.KEY_INFO])
-    return key
+    try:
+        data = json[mc.KEY_DATA]
+        if data:
+            key = data[mc.KEY_KEY]
+            if key:
+                return key
+    except:
+        pass
+    # key not present for any reason
+    if isinstance(info := json.get(mc.KEY_INFO), str):
+        raise MerossApiError(info)
+    # fallback to raise the entire response
+    raise MerossApiError(json_dumps(json))
+
 
 
 class MerossDeviceDescriptor:
@@ -232,6 +242,8 @@ class MerossDeviceDescriptor:
         self.system[mc.KEY_TIME] = p_time
         self.time = p_time
         self.timezone = p_time.get(mc.KEY_TIMEZONE)
+
+
 
 class MerossHttpClient:
 

--- a/custom_components/meross_lan/merossclient/__init__.py
+++ b/custom_components/meross_lan/merossclient/__init__.py
@@ -9,10 +9,11 @@ from json import (
     dumps as json_dumps,
     loads as json_loads,
 )
-from xmlrpc.client import Boolean
-import aiohttp
-import async_timeout
 import asyncio
+import async_timeout
+import aiohttp
+
+
 from yarl import URL
 
 from . import const as mc
@@ -53,6 +54,12 @@ class MerossSignatureError(MerossProtocolError):
     """
     def __init__(self):
         super().__init__("Signature error")
+
+
+class MerossApiError(MerossProtocolError):
+    """
+    signals an error when connecting to the public API endpoint
+    """
 
 
 def build_payload(
@@ -170,7 +177,10 @@ async def async_get_cloud_key(username, password, session: aiohttp.client.Client
         )
         response.raise_for_status()
     json: dict = await response.json()
-    return json.get(mc.KEY_DATA, {}).get(mc.KEY_KEY)
+    key = json.get(mc.KEY_DATA, {}).get(mc.KEY_KEY)
+    if key is None:
+        raise MerossApiError(json[mc.KEY_INFO])
+    return key
 
 
 class MerossDeviceDescriptor:

--- a/custom_components/meross_lan/merossclient/const.py
+++ b/custom_components/meross_lan/merossclient/const.py
@@ -67,9 +67,11 @@ NS_APPLIANCE_HUB_EXCEPTION = 'Appliance.Hub.Exception'
 NS_APPLIANCE_HUB_BATTERY = 'Appliance.Hub.Battery'
 NS_APPLIANCE_HUB_TOGGLEX = 'Appliance.Hub.ToggleX'
 NS_APPLIANCE_HUB_ONLINE = 'Appliance.Hub.Online'
+NS_APPLIANCE_HUB_PAIRSUBDEV = 'Appliance.Hub.PairSubDev'
 # miscellaneous
 NS_APPLIANCE_HUB_SUBDEVICE_MOTORADJUST = 'Appliance.Hub.SubDevice.MotorAdjust'
-# MS100
+NS_APPLIANCE_HUB_SUBDEVICE_BEEP = 'Appliance.Hub.SubDevice.Beep'
+# MS100 and other sensors
 NS_APPLIANCE_HUB_SENSOR_ALL = 'Appliance.Hub.Sensor.All'
 NS_APPLIANCE_HUB_SENSOR_TEMPHUM = 'Appliance.Hub.Sensor.TempHum'
 NS_APPLIANCE_HUB_SENSOR_ALERT = 'Appliance.Hub.Sensor.Alert'
@@ -182,6 +184,8 @@ KEY_LATEST = 'latest'
 KEY_TEMPHUM = 'tempHum'
 KEY_LATESTTEMPERATURE = 'latestTemperature'
 KEY_LATESTHUMIDITY = 'latestHumidity'
+KEY_SMOKEALARM = 'smokeAlarm'
+KEY_INTERCONN = 'interConn'
 KEY_SCHEDULE = 'schedule'
 KEY_ELECTRICITY = 'electricity'
 KEY_POWER = 'power'
@@ -254,6 +258,7 @@ PAYLOAD_GET = {
     NS_APPLIANCE_ROLLERSHUTTER_CONFIG: { KEY_CONFIG: [] },
     NS_APPLIANCE_HUB_BATTERY: { KEY_BATTERY: [] },
     NS_APPLIANCE_HUB_SENSOR_ALL: { KEY_ALL: [] },
+    NS_APPLIANCE_HUB_SENSOR_SMOKE: { KEY_SMOKEALARM: [] }, # guessing: 'smoke' is wrong for sure
     NS_APPLIANCE_HUB_MTS100_ALL: { KEY_ALL: [] },
     NS_APPLIANCE_HUB_MTS100_SCHEDULEB: { KEY_SCHEDULE: [] },
     NS_APPLIANCE_HUB_SUBDEVICE_MOTORADJUST: { KEY_ADJUST: [] }, # unconfirmed but 'motoradjust' is wrong for sure
@@ -385,6 +390,10 @@ TYPE_NAME_MAP[TYPE_MS100] = "Smart Temp/Humidity Sensor"
 
 TYPE_HP110A = 'hp110'
 TYPE_NAME_MAP[TYPE_HP110A] = "Smart Cherub Baby Machine"
+
+#this is how the GS559 smart smoke alarm is reported in digest.hub.subdevice
+TYPE_SMOKEALARM = KEY_SMOKEALARM
+TYPE_NAME_MAP[TYPE_SMOKEALARM] = "Smart Smoke Alarm"
 
 """
     GP constant strings

--- a/custom_components/meross_lan/number.py
+++ b/custom_components/meross_lan/number.py
@@ -14,13 +14,15 @@ except:
     NUMBERMODE_BOX = "box"
     NUMBERMODE_SLIDER = "slider"
 
+CORE_HAS_NATIVE_UNIT = hasattr(NumberEntity, 'native_unit_of_measurement')
+
 from .merossclient import const as mc, get_namespacekey  # mEROSS cONST
 from .meross_entity import (
     _MerossEntity,
     platform_setup_entry, platform_unload_entry,
     ENTITY_CATEGORY_CONFIG,
 )
-
+from .sensor import CLASS_TO_UNIT_MAP
 
 
 async def async_setup_entry(hass: object, config_entry: object, async_add_devices):
@@ -30,26 +32,110 @@ async def async_unload_entry(hass: object, config_entry: object) -> bool:
     return platform_unload_entry(hass, config_entry, PLATFORM_NUMBER)
 
 
-class MLConfigNumber(_MerossEntity, NumberEntity):
+if CORE_HAS_NATIVE_UNIT:
+    # implement 'new' (2022.6) style NumberEntity
+    class MLConfigNumber(_MerossEntity, NumberEntity):
 
-    PLATFORM = PLATFORM_NUMBER
+        PLATFORM = PLATFORM_NUMBER
 
-    multiplier = 1
+        multiplier = 1
 
-    _attr_mode = NUMBERMODE_BOX
-
-    @property
-    def entity_category(self):
-        return ENTITY_CATEGORY_CONFIG
-
-
-    @property
-    def value(self) -> float | None:
-        return self._attr_state
+        _attr_mode = NUMBERMODE_BOX
+        _attr_native_max_value: float
+        _attr_native_min_value: float
+        _attr_native_step: float
+        _attr_native_unit_of_measurement: str | None
 
 
-    def update_value(self, value):
-        self.update_state(value / self.multiplier)
+        @property
+        def entity_category(self):
+            return ENTITY_CATEGORY_CONFIG
+
+        @property
+        def native_max_value(self):
+            return self._attr_native_max_value
+
+        @property
+        def native_min_value(self):
+            return self._attr_native_min_value
+
+        @property
+        def native_step(self):
+            return self._attr_native_step
+
+        @property
+        def native_unit_of_measurement(self):
+            return self._attr_native_unit_of_measurement
+
+        @property
+        def native_value(self) -> float | None:
+            return self._attr_state
+
+        def update_native_value(self, value):
+            self.update_state(value / self.multiplier)
+
+else:
+    # pre 2022.6 style NumberEntity
+    # since derived classes will try to adapt to new _native_* style
+    # here we adapt for older HA cores
+    class MLConfigNumber(_MerossEntity, NumberEntity):
+
+        PLATFORM = PLATFORM_NUMBER
+
+        multiplier = 1
+
+        _attr_mode = NUMBERMODE_BOX
+        _attr_native_max_value: float
+        _attr_native_min_value: float
+        _attr_native_step: float
+        _attr_native_unit_of_measurement: str | None
+
+
+        @property
+        def entity_category(self):
+            return ENTITY_CATEGORY_CONFIG
+
+        @property
+        def native_max_value(self):
+            return self._attr_native_max_value
+
+        @property
+        def native_min_value(self):
+            return self._attr_native_min_value
+
+        @property
+        def native_step(self):
+            return self._attr_native_step
+
+        @property
+        def native_unit_of_measurement(self):
+            return self._attr_native_unit_of_measurement
+
+        @property
+        def max_value(self) -> float:
+            return self.native_max_value
+
+        @property
+        def min_value(self) -> float:
+            return self.native_min_value
+
+        @property
+        def step(self) -> float:
+            return self.native_step
+
+        @property
+        def unit_of_measurement(self) -> str | None:
+            return self.native_unit_of_measurement
+
+        @property
+        def value(self) -> float | None:
+            return self._attr_state
+
+        def update_native_value(self, value):
+            self.update_state(value / self.multiplier)
+
+        async def async_set_value(self, value: float):
+            await self.async_set_native_value(value)
 
 
 class MLHubAdjustNumber(MLConfigNumber):
@@ -71,9 +157,10 @@ class MLHubAdjustNumber(MLConfigNumber):
         self._namespace = namespace
         self._namespace_key = get_namespacekey(namespace)
         self._label = label
-        self._attr_min_value = min_value
-        self._attr_max_value = max_value
-        self._attr_step = step
+        self._attr_native_min_value = min_value
+        self._attr_native_max_value = max_value
+        self._attr_native_step = step
+        self._attr_native_unit_of_measurement = CLASS_TO_UNIT_MAP.get(device_class)
         super().__init__(
             subdevice.hub,
             subdevice.id,
@@ -87,8 +174,7 @@ class MLHubAdjustNumber(MLConfigNumber):
         return f"{self.subdevice.name} - adjust {self._label} {self._attr_device_class}"
 
 
-    async def async_set_value(self, value: float) -> None:
-
+    async def async_set_native_value(self, value: float):
         self.device.request(
             self._namespace,
             mc.METHOD_SET,

--- a/custom_components/meross_lan/sensor.py
+++ b/custom_components/meross_lan/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.components.sensor import (
     DOMAIN as PLATFORM_SENSOR,
 )
+from homeassistant.util.dt import now
 
 try:
     from homeassistant.components.sensor import SensorEntity
@@ -210,9 +211,9 @@ class ConsumptionMixin:
         days_len = len(days)
         if days_len < 1:
             if STATE_CLASS_TOTAL_INCREASING == STATE_CLASS_MEASUREMENT:
-                self._sensor_energy._attr_last_reset = datetime.utcfromtimestamp(0)
+                self._sensor_energy._attr_last_reset = now()
             self._sensor_energy.update_state(0)
-            return True
+            return
         # we'll look through the device array values to see
         # data timestamped (in device time) after last midnight
         # since we usually reset this around midnight localtime
@@ -234,7 +235,7 @@ class ConsumptionMixin:
         days = sorted(days, key=get_timestamp, reverse=True)
         day_last:dict = days[0]
         if day_last.get(mc.KEY_TIME) < timestamp_lastreset:
-            return True
+            return
         if days_len > 1:
             timestamp_lastreset = days[1].get(mc.KEY_TIME)
         if self._lastreset_energy != timestamp_lastreset:

--- a/custom_components/meross_lan/strings.json
+++ b/custom_components/meross_lan/strings.json
@@ -28,7 +28,7 @@
           },
           "device": {
               "title": "Meross LAN",
-              "description": "Setup meross device",
+              "description": "Setup meross device\nType: {device_type}\nUUID: {device_id}",
               "data": {
                   "host": "Device host address",
                   "keymode": "Key selection mode",
@@ -68,7 +68,7 @@
           },
           "device": {
               "title": "Device configuration",
-              "description": "Type: {device_type}\nUUID: {device_id}\nHost: {host}\n\n{payload}",
+              "description": "Type: {device_type}\nUUID: {device_id}\nHost: {host}",
               "data": {
                   "host": "Device host address",
                   "keymode": "Key selection mode",

--- a/custom_components/meross_lan/translations/cs.json
+++ b/custom_components/meross_lan/translations/cs.json
@@ -30,7 +30,7 @@
             },
             "device": {
                 "title": "Meross LAN",
-                "description": "Nastavení zařízení Meross",
+                "description": "Nastavení zařízení Meross\nTyp: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "Adresa hostitele zařízení",
                     "keymode": "Key selection mode",
@@ -71,7 +71,7 @@
             },
             "device": {
                 "title": "Konfigurace zařízení",
-                "description": "Typ: {device_type}\nIdentifikátor UUID: {device_id}\nHostitel: {host}\n\n{payload}",
+                "description": "Typ: {device_type}\nIdentifikátor UUID: {device_id}\nHostitel: {host}",
                 "data": {
                     "host": "Adresa hostitele zařízení",
                     "keymode": "Key selection mode",

--- a/custom_components/meross_lan/translations/de.json
+++ b/custom_components/meross_lan/translations/de.json
@@ -28,7 +28,7 @@
             },
             "device": {
                 "title": "Meross LAN",
-                "description": "Meross Gerät einrichten",
+                "description": "Meross Gerät einrichten\nTyp: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "IP-Adresse des Geräts",
                     "keymode": "Schlüsselauswahlmodus",
@@ -68,7 +68,7 @@
             },
             "device": {
                 "title": "Gerätekonfiguration",
-                "description": "Typ: {device_type}\nUUID: {device_id}\nHost: {host}\n\n{payload}",
+                "description": "Typ: {device_type}\nUUID: {device_id}\nHost: {host}",
                 "data": {
                     "host": "IP-Adresse des Geräts",
                     "keymode": "Schlüsselauswahlmodus",

--- a/custom_components/meross_lan/translations/en.json
+++ b/custom_components/meross_lan/translations/en.json
@@ -28,7 +28,7 @@
             },
             "device": {
                 "title": "Meross LAN",
-                "description": "Setup meross device",
+                "description": "Setup meross device\nType: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "Device host address",
                     "keymode": "Key selection mode",
@@ -68,7 +68,7 @@
             },
             "device": {
                 "title": "Device configuration",
-                "description": "Type: {device_type}\nUUID: {device_id}\nHost: {host}\n\n{payload}",
+                "description": "Type: {device_type}\nUUID: {device_id}\nHost: {host}",
                 "data": {
                     "host": "Device host address",
                     "keymode": "Key selection mode",

--- a/custom_components/meross_lan/translations/es.json
+++ b/custom_components/meross_lan/translations/es.json
@@ -28,7 +28,7 @@
             },
             "device": {
                 "title": "Meross LAN",
-                "description": "Configurar un dispositivo meross",
+                "description": "Configurar un dispositivo meross\nTipo: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "Dirección IP del dispositivo",
                     "keymode": "Modo de selección de clave",
@@ -68,7 +68,7 @@
             },
             "device": {
                 "title": "Cónfiguración de dispositivo",
-                "description": "Tipo: {device_type}\nUUID: {device_id}\nDirección IP: {host}\n\n{payload}",
+                "description": "Tipo: {device_type}\nUUID: {device_id}\nDirección IP: {host}",
                 "data": {
                     "host": "Dirección IP del dispositivo",
                     "keymode": "Modo de selección de clave",

--- a/custom_components/meross_lan/translations/fr.json
+++ b/custom_components/meross_lan/translations/fr.json
@@ -28,7 +28,7 @@
       },
       "device": {
         "title": "Meross LAN",
-        "description": "Découvrir l'appareil",
+        "description": "Découvrir l'appareil\nType: {device_type}\nUUID: {device_id}",
         "data": {
           "host": "Adresse",
           "keymode": "Mode de sélection de clé",
@@ -68,7 +68,7 @@
       },
       "device": {
         "title": "Configuration de l'appareil",
-        "description": "Type: {device_type}\nUUID: {device_id}\nHost: {host}\n\n{payload}",
+        "description": "Type: {device_type}\nUUID: {device_id}\nHost: {host}",
         "data": {
           "host": "Adresse",
           "keymode": "Mode de sélection de clé",

--- a/custom_components/meross_lan/translations/it.json
+++ b/custom_components/meross_lan/translations/it.json
@@ -28,7 +28,7 @@
             },
             "device": {
                 "title": "Meross LAN",
-                "description": "Configurazione dispositivo",
+                "description": "Configurazione dispositivo\nTipo: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "Indirizzo dispositivo",
                     "keymode": "Selezione chiave",
@@ -68,7 +68,7 @@
             },
             "device": {
                 "title": "Configurazione dispositivo",
-                "description": "Tipo: {device_type}\nUUID: {device_id}\nHost: {host}\n\n{payload}",
+                "description": "Tipo: {device_type}\nUUID: {device_id}\nHost: {host}",
                 "data": {
                     "host": "Indirizzo dispositivo",
                     "keymode": "Selezione chiave",

--- a/custom_components/meross_lan/translations/ja.json
+++ b/custom_components/meross_lan/translations/ja.json
@@ -28,10 +28,10 @@
             },
             "device": {
                 "title": "Meross LAN",
-                "description": "Meross デバイスのセットアップ",
+                "description": "Meross デバイスのセットアップ\nタイップ: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "デバイスのホストアドレス",
-                    "keymode": "Key selection mode",
+                    "keymode": "キー selection mode",
                     "key": "デバイスキー"
                 }
             },
@@ -45,7 +45,7 @@
             },
             "finalize": {
                 "title": "デバイス設定",
-                "description": "Type: {device_type}\nUUID: {device_id}",
+                "description": "タイップ: {device_type}\nUUID: {device_id}",
                 "data": {}
             }
         }
@@ -68,7 +68,7 @@
             },
             "device": {
                 "title": "デバイス設定",
-                "description": "Type: {device_type}\nUUID: {device_id}\nHost: {host}\n\n{payload}",
+                "description": "タイップ: {device_type}\nUUID: {device_id}\nホストアドレス: {host}",
                 "data": {
                     "host": "デバイスのホストアドレス",
                     "keymode": "Key selection mode",


### PR DESCRIPTION
This is mainly a maintenance release bringing to the general public all of the fixes and small improvements published in the pre-release channel.
The following list summarizes the relevant changes against the last 'Dare.1' stable release

# features
- expose cloud retrieve error info (#186)
- implementation for smokeAlarm (#183)
- restore shutter/garage state between HA restarts (#170)
- update NumberEntity to new HA core model (#198)
- update enum/constants to new HA core model
- show device UUID on configuration form to help identify issues with #88 

# fixes
- username/password encoding (for 'exotic' characters) in cloud key retrieve form (#186)
- inconsistent key mode behaviour in OptionFlow (#176)
- shutter/garage state restoration error on 2022.6 (#195)
- mod100 bug introduced in previous 'alpha' (#187)