### PR TITLE
Release Keep.1

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -26,7 +26,7 @@ jobs:
         - uses: "actions/checkout@v2"
         - uses: "actions/setup-python@v1"
           with:
-            python-version: "3.x"
+            python-version: "3.9"
         - run: python3 -m pip install black
         - run: black .
 
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Python
         uses: "actions/setup-python@v1"
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install requirements
         run: python3 -m pip install -r requirements_test.txt
       - name: Run tests

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
         - uses: "actions/checkout@v2"
         - uses: "actions/setup-python@v1"
           with:
-            python-version: "3.x"
+            python-version: "3.9"
         - run: python3 -m pip install black
         - run: black .
 
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Python
         uses: "actions/setup-python@v1"
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install requirements
         run: python3 -m pip install -r requirements_test.txt
       - name: Run tests

--- a/custom_components/meross_lan/helpers.py
+++ b/custom_components/meross_lan/helpers.py
@@ -97,28 +97,34 @@ def deobfuscate(payload: dict, obfuscated: dict):
 """
 MQTT helpers
 """
-from homeassistant.components.mqtt import DATA_MQTT
-
 def mqtt_is_loaded(hass) -> bool:
     """
     check if any MQTT is configured
     """
+    from homeassistant.components.mqtt import DATA_MQTT
     return hass.data.get(DATA_MQTT) is not None
+
 
 def mqtt_is_connected(hass) -> bool:
     """
     check if MQTT communication is available
     """
-    mqtt = hass.data.get(DATA_MQTT)
-    return mqtt.connected if mqtt is not None else False
+    from homeassistant.components.mqtt import is_connected
+    return is_connected(hass)
+
 
 def mqtt_publish(hass, topic, payload):
     """
     friendly 'publish' to bypass official core/mqtt interface variations
     this could be dangerous on compatibility but the ongoing api changes (2021.12.0)
     are a bit too much to follow with a clean backward compatible code
+    EDIT 2022-09-29:
+    following recent issues (#213 - HA core 2022.9.6) this code is reverted
+    to using the official api for the mqtt component. In doing so we're likely
+    breaking compatibility with pre 2021.12.0
     """
-    hass.async_create_task(hass.data[DATA_MQTT].async_publish(topic, payload, 0, False))
+    from homeassistant.components.mqtt import publish
+    publish(hass, topic, payload)
 
 
 """

--- a/custom_components/meross_lan/manifest.json
+++ b/custom_components/meross_lan/manifest.json
@@ -13,5 +13,5 @@
   "dependencies": ["recorder"],
   "after_dependencies": ["mqtt", "dhcp"],
   "codeowners": ["@krahabb"],
-  "version": "2.6.1"
+  "version": "2.6.2-alpha.0"
 }

--- a/custom_components/meross_lan/manifest.json
+++ b/custom_components/meross_lan/manifest.json
@@ -13,5 +13,5 @@
   "dependencies": ["recorder"],
   "after_dependencies": ["mqtt", "dhcp"],
   "codeowners": ["@krahabb"],
-  "version": "2.6.2-alpha.0"
+  "version": "2.6.2"
 }

--- a/custom_components/meross_lan/meross_device_hub.py
+++ b/custom_components/meross_lan/meross_device_hub.py
@@ -228,7 +228,7 @@ class MerossDeviceHub(MerossDevice):
                 # now we're left with non-existent (removed) subdevices
                 self.needsave = True
                 for p_id in subdevices_actual:
-                    subdevice = self.subdevices.pop(p_id)
+                    subdevice = self.subdevices.get(p_id)
                     self.log(logging.WARNING, 0, "removing subdevice %s(%s) - configuration will be reloaded in 15 sec", subdevice.type, p_id)
                 """
                 before reloading we have to be sure configentry data were persisted

--- a/custom_components/meross_lan/strings.json
+++ b/custom_components/meross_lan/strings.json
@@ -15,7 +15,6 @@
       },
       "step": {
           "user": {
-              "title": "Meross LAN",
               "description": "Setup meross device",
               "data": {}
           },
@@ -27,7 +26,6 @@
               }
           },
           "device": {
-              "title": "Meross LAN",
               "description": "Setup meross device\nType: {device_type}\nUUID: {device_id}",
               "data": {
                   "host": "Device host address",

--- a/custom_components/meross_lan/strings.json
+++ b/custom_components/meross_lan/strings.json
@@ -1,5 +1,4 @@
 {
-  "title": "Meross LAN",
   "config": {
       "flow_title": "Meross {device_type}",
       "abort": {

--- a/custom_components/meross_lan/translations/cs.json
+++ b/custom_components/meross_lan/translations/cs.json
@@ -15,7 +15,6 @@
         },
         "step": {
             "user": {
-                "title": "Meross LAN",
                 "description": "Nastavení zařízení Meross",
                 "data": {
                     "Required": "Povinné pole"
@@ -29,7 +28,6 @@
                 }
             },
             "device": {
-                "title": "Meross LAN",
                 "description": "Nastavení zařízení Meross\nTyp: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "Adresa hostitele zařízení",

--- a/custom_components/meross_lan/translations/cs.json
+++ b/custom_components/meross_lan/translations/cs.json
@@ -1,5 +1,4 @@
 {
-    "title": "Meross LAN",
     "config": {
         "flow_title": "Meross {device_type}",
         "abort": {

--- a/custom_components/meross_lan/translations/de.json
+++ b/custom_components/meross_lan/translations/de.json
@@ -15,7 +15,6 @@
         },
         "step": {
             "user": {
-                "title": "Meross LAN",
                 "description": "Meross Gerät einrichten",
                 "data": {}
             },
@@ -27,7 +26,6 @@
                 }
             },
             "device": {
-                "title": "Meross LAN",
                 "description": "Meross Gerät einrichten\nTyp: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "IP-Adresse des Geräts",

--- a/custom_components/meross_lan/translations/de.json
+++ b/custom_components/meross_lan/translations/de.json
@@ -1,5 +1,4 @@
 {
-    "title": "Meross LAN",
     "config": {
         "flow_title": "Meross {device_type}",
         "abort": {

--- a/custom_components/meross_lan/translations/en.json
+++ b/custom_components/meross_lan/translations/en.json
@@ -15,7 +15,6 @@
         },
         "step": {
             "user": {
-                "title": "Meross LAN",
                 "description": "Setup meross device",
                 "data": {}
             },
@@ -27,7 +26,6 @@
                 }
             },
             "device": {
-                "title": "Meross LAN",
                 "description": "Setup meross device\nType: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "Device host address",

--- a/custom_components/meross_lan/translations/en.json
+++ b/custom_components/meross_lan/translations/en.json
@@ -1,5 +1,4 @@
 {
-    "title": "Meross LAN",
     "config": {
         "flow_title": "Meross {device_type}",
         "abort": {

--- a/custom_components/meross_lan/translations/es.json
+++ b/custom_components/meross_lan/translations/es.json
@@ -15,7 +15,6 @@
         },
         "step": {
             "user": {
-                "title": "Meross LAN",
                 "description": "Configurar un dispositivo meross",
                 "data": {}
             },

--- a/custom_components/meross_lan/translations/es.json
+++ b/custom_components/meross_lan/translations/es.json
@@ -26,7 +26,6 @@
                 }
             },
             "device": {
-                "title": "Meross LAN",
                 "description": "Configurar un dispositivo meross\nTipo: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "Dirección IP del dispositivo",

--- a/custom_components/meross_lan/translations/es.json
+++ b/custom_components/meross_lan/translations/es.json
@@ -1,5 +1,4 @@
 {
-    "title": "Meross LAN",
     "config": {
         "flow_title": "Meross {device_type}",
         "abort": {

--- a/custom_components/meross_lan/translations/fr.json
+++ b/custom_components/meross_lan/translations/fr.json
@@ -15,7 +15,6 @@
     },
     "step": {
       "user": {
-        "title": "Meross LAN",
         "description": "Découvrir l'appareil",
         "data": {}
       },

--- a/custom_components/meross_lan/translations/fr.json
+++ b/custom_components/meross_lan/translations/fr.json
@@ -1,5 +1,4 @@
 {
-  "title": "Meross LAN",
   "config": {
     "flow_title": "Meross {device_type}",
     "abort": {

--- a/custom_components/meross_lan/translations/fr.json
+++ b/custom_components/meross_lan/translations/fr.json
@@ -26,7 +26,6 @@
         }
       },
       "device": {
-        "title": "Meross LAN",
         "description": "Découvrir l'appareil\nType: {device_type}\nUUID: {device_id}",
         "data": {
           "host": "Adresse",

--- a/custom_components/meross_lan/translations/it.json
+++ b/custom_components/meross_lan/translations/it.json
@@ -1,5 +1,4 @@
 {
-    "title": "Meross LAN",
     "config": {
         "flow_title": "Meross {device_type}",
         "abort": {

--- a/custom_components/meross_lan/translations/it.json
+++ b/custom_components/meross_lan/translations/it.json
@@ -15,7 +15,6 @@
         },
         "step": {
             "user": {
-                "title": "Meross LAN",
                 "description": "Configurazione dispositivo",
                 "data": {}
             },
@@ -27,7 +26,6 @@
                 }
             },
             "device": {
-                "title": "Meross LAN",
                 "description": "Configurazione dispositivo\nTipo: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "Indirizzo dispositivo",

--- a/custom_components/meross_lan/translations/ja.json
+++ b/custom_components/meross_lan/translations/ja.json
@@ -1,5 +1,4 @@
 {
-    "title": "Meross LAN",
     "config": {
         "flow_title": "Meross {device_type}",
         "abort": {

--- a/custom_components/meross_lan/translations/ja.json
+++ b/custom_components/meross_lan/translations/ja.json
@@ -15,7 +15,6 @@
         },
         "step": {
             "user": {
-                "title": "Meross LAN",
                 "description": "Meross デバイスのセットアップ",
                 "data": {}
             },
@@ -27,7 +26,6 @@
                 }
             },
             "device": {
-                "title": "Meross LAN",
                 "description": "Meross デバイスのセットアップ\nタイップ: {device_type}\nUUID: {device_id}",
                 "data": {
                     "host": "デバイスのホストアドレス",

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
   "name": "Meross LAN",
   "render_readme": true,
   "country": ["IT", "GB", "US", "JP", "ES", "FR", "DE"],
-  "homeassistant": "2021.4.0",
+  "homeassistant": "2022.1.0",
   "persistent_directory": "traces",
   "hacs": "1.6.0"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,1 @@
-homeassistant
+homeassistant>=2022.9.7

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
 -r requirements_dev.txt
 aiodiscover
-pytest-homeassistant-custom-component==0.5.1
+pytest-homeassistant-custom-component==0.11.26


### PR DESCRIPTION
This is a small bugfix release to improve compatibility against HA core 2022.9.6 and later

# fixes
- MQTT api error preventing MQTT communication since HA core 2022.9.6 (#213)
- duplicate IDs in meross hub devices (thermostat valves and any other hub paired item) (#214)
