### PR TITLE
Fix device entities not showing up after reconnection

### DIFF
--- a/custom_components/meross_lan/meross_device.py
+++ b/custom_components/meross_lan/meross_device.py
@@ -359,6 +359,11 @@ class MerossDevice:
         if not self._online:
             self.log(DEBUG, 0, "MerossDevice(%s) back online!", self.name)
             self._online = True
+            # Make sure we get the full device state to prevent switches stay 
+            # disabled because the device does not push any updates for the switch state
+            self.api.hass.async_create_task(
+                self.async_request_get(mc.NS_APPLIANCE_SYSTEM_ALL)
+            )
             self.api.hass.async_create_task(
                 self.async_request_updates(epoch, namespace)
             )


### PR DESCRIPTION
This fixes the issue of switch entities not becoming available after reconnecting my mss310EU plugs v6

This should fix missing availability after reconnection for any device that brings both entities that push state and that do not push state on their own


The issue with the mss310 plugs results from the `_async_polling_callback` never triggering a full device state update after a reconnection. I think this happens because the device has some power measurement entities that push updates right after rejoining, which leads to `this.lastupdate` being updated despite some entities state being missing and corresponding entities staying marked as unavailable. 

**Left as draft for now to discuss if there is maybe a better approach.**

Re-querying _Appliance.System.All_ when a device is recovering from being offline should not break things, however i cannot test this with other devices and this most likely also leads to querying full state twice on the first initialization.. 

I'd be grateful if someone more knowledgeable with the architecture can chime in.
