### PR TITLE
Release Lazy.3

### DIFF
--- a/custom_components/meross_lan/__init__.py
+++ b/custom_components/meross_lan/__init__.py
@@ -570,7 +570,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if not await hass.config_entries.async_unload_platforms(entry, device.platforms.keys()):
                 return False
             api.devices.pop(device_id)
-            device.shutdown()
+            await device.async_shutdown()
         #don't cleanup: the MerossApi is still needed to detect MQTT discoveries
         #if (not api.devices) and (len(hass.config_entries.async_entries(DOMAIN)) == 1):
         #    api.shutdown()

--- a/custom_components/meross_lan/cover.py
+++ b/custom_components/meross_lan/cover.py
@@ -195,6 +195,7 @@ class MLGarageOpenCloseDurationNumber(MLGarageConfigNumber):
         ) / 2)
 
     async def async_added_to_hass(self):
+        await super().async_added_to_hass()
         try:
             if last_state := await get_entity_last_state(self.hass, self.entity_id):
                 self._attr_state = float(last_state.state) # type: ignore
@@ -260,6 +261,7 @@ class MLGarage(me.MerossEntity, CoverEntity):
         return self._attr_state == STATE_CLOSED
 
     async def async_added_to_hass(self):
+        await super().async_added_to_hass()
         """
         we're trying to recover the '_transition_duration' from previous state
         """
@@ -336,7 +338,8 @@ class MLGarage(me.MerossEntity, CoverEntity):
 
     async def async_will_remove_from_hass(self):
         self._cancel_transition()
-
+        await super().async_will_remove_from_hass()
+        
     def set_unavailable(self):
         self._open = None
         self._cancel_transition()
@@ -604,6 +607,7 @@ class MLRollerShutter(me.MerossEntity, CoverEntity):
         return self._attr_state == STATE_CLOSED
 
     async def async_added_to_hass(self):
+        await super().async_added_to_hass()
         """
         we're trying to recover the 'timed' position from previous state
         if it happens it wasn't updated too far in time

--- a/custom_components/meross_lan/emulator/descriptor.py
+++ b/custom_components/meross_lan/emulator/descriptor.py
@@ -5,9 +5,8 @@
     in case we need some special behavor
 """
 from __future__ import annotations
-from json import (
-    loads as json_loads,
-)
+
+from json import loads as json_loads
 
 from custom_components.meross_lan.merossclient import (
     MerossDeviceDescriptor,
@@ -18,14 +17,12 @@ from custom_components.meross_lan.merossclient import (
 
 class MerossEmulatorDescriptor(MerossDeviceDescriptor):
 
-
     namespaces: dict
 
-
-    def __init__(self, tracefile:str, uuid):
+    def __init__(self, tracefile: str, uuid):
         self.namespaces = {}
-        with open(tracefile, 'r', encoding='utf8') as f:
-            if tracefile.endswith('.json.txt'):
+        with open(tracefile, "r", encoding="utf8") as f:
+            if tracefile.endswith(".json.txt"):
                 # HA diagnostics trace
                 self._import_json(f)
             else:
@@ -38,15 +35,13 @@ class MerossEmulatorDescriptor(MerossDeviceDescriptor):
         hardware[mc.KEY_UUID] = uuid
         hardware[mc.KEY_MACADDRESS] = uuid[-12:]
 
-
     def _import_tsv(self, f):
         """
         parse a legacy tab separated values meross_lan trace
         """
         for line in f:
-            row = line.split('\t')
+            row = line.split("\t")
             self._import_tracerow(row)
-
 
     def _import_json(self, f):
         """
@@ -54,9 +49,9 @@ class MerossEmulatorDescriptor(MerossDeviceDescriptor):
         """
         try:
             _json = json_loads(f.read())
-            data = _json['data']
+            data = _json["data"]
             columns = None
-            for row in data['trace']:
+            for row in data["trace"]:
                 if columns is None:
                     columns = row
                     # we could parse and setup a 'column search'
@@ -70,17 +65,20 @@ class MerossEmulatorDescriptor(MerossDeviceDescriptor):
 
         return
 
-
     def _import_tracerow(self, values: list):
-        #rxtx = values[1]
+        # rxtx = values[1]
         protocol = values[-4]
         method = values[-3]
         namespace = values[-2]
         data = values[-1]
         if method == mc.METHOD_GETACK:
-            if protocol == 'auto':
+            if protocol == "auto":
                 self.namespaces[namespace] = {
-                    get_namespacekey(namespace): data if isinstance(data, dict) else json_loads(data)
+                    get_namespacekey(namespace): data
+                    if isinstance(data, dict)
+                    else json_loads(data)
                 }
             else:
-                self.namespaces[namespace] = data if isinstance(data, dict) else json_loads(data)
+                self.namespaces[namespace] = (
+                    data if isinstance(data, dict) else json_loads(data)
+                )

--- a/custom_components/meross_lan/emulator/emulator.py
+++ b/custom_components/meross_lan/emulator/emulator.py
@@ -12,11 +12,10 @@
 
 """
 from __future__ import annotations
+
+from json import dumps as json_dumps, loads as json_loads
 from time import time
-from json import (
-    dumps as json_dumps,
-    loads as json_loads,
-)
+from zoneinfo import ZoneInfo
 
 from custom_components.meross_lan.merossclient import (
     build_payload,
@@ -30,38 +29,57 @@ from .descriptor import MerossEmulatorDescriptor
 
 class MerossEmulator:
 
+    _tzinfo: ZoneInfo | None = None
 
     def __init__(self, descriptor: MerossEmulatorDescriptor, key):
         self.key = key
         self.descriptor = descriptor
         self.p_all_system_time = descriptor.system.get(mc.KEY_TIME)
         if mc.NS_APPLIANCE_SYSTEM_DNDMODE in descriptor.ability:
-            self.p_dndmode = { mc.KEY_DNDMODE: { mc.KEY_MODE: 0 }}
-
+            self.p_dndmode = {mc.KEY_DNDMODE: {mc.KEY_MODE: 0}}
+        self.update_epoch()
         print(f"Initialized {descriptor.productname} (model:{descriptor.productmodel})")
 
-    #async def post_config(self, request: web_Request):
+    @property
+    def tzinfo(self):
+        tz_name = self.descriptor.timezone
+        if not tz_name:
+            return None
+        if (self._tzinfo is not None) and (self._tzinfo.key == tz_name):
+            return self._tzinfo
+        try:
+            self._tzinfo = ZoneInfo(tz_name)
+        except Exception:
+            self._tzinfo = None
+        return self._tzinfo
+
+    # async def post_config(self, request: web_Request):
     def handle(self, request: str) -> dict:
         jsonrequest = json_loads(request)
-        header:dict = jsonrequest[mc.KEY_HEADER]
-        payload:dict = jsonrequest[mc.KEY_PAYLOAD]
-        namespace:str = header[mc.KEY_NAMESPACE]
-        method:str = header[mc.KEY_METHOD]
+        header: dict = jsonrequest[mc.KEY_HEADER]
+        payload: dict = jsonrequest[mc.KEY_PAYLOAD]
+        namespace: str = header[mc.KEY_NAMESPACE]
+        method: str = header[mc.KEY_METHOD]
 
-        print(f"Emulator({self.descriptor.uuid}) "
-              f"RX: namespace={namespace} method={method} payload={json_dumps(payload)}")
+        print(
+            f"Emulator({self.descriptor.uuid}) "
+            f"RX: namespace={namespace} method={method} payload={json_dumps(payload)}"
+        )
         try:
-            if self.p_all_system_time is not None:
-                self.p_all_system_time[mc.KEY_TIMESTAMP] = int(time())
+            self.update_epoch()
 
             if namespace not in self.descriptor.ability:
                 raise Exception(f"{namespace} not supported in ability")
 
             elif get_replykey(header, self.key) is not self.key:
                 method = mc.METHOD_ERROR
-                payload = { mc.KEY_ERROR: { mc.KEY_CODE: mc.ERROR_INVALIDKEY} }
+                payload = {mc.KEY_ERROR: {mc.KEY_CODE: mc.ERROR_INVALIDKEY}}
 
-            elif (handler := getattr(self, f"_{method}_{namespace.replace('.', '_')}", None)) is not None:
+            elif (
+                handler := getattr(
+                    self, f"_{method}_{namespace.replace('.', '_')}", None
+                )
+            ) is not None:
                 method, payload = handler(header, payload)
 
             else:
@@ -69,11 +87,25 @@ class MerossEmulator:
 
         except Exception as e:
             method = mc.METHOD_ERROR
-            payload = { mc.KEY_ERROR: { mc.KEY_CODE: -1, "message": str(e)} }
+            payload = {mc.KEY_ERROR: {mc.KEY_CODE: -1, "message": str(e)}}
 
-        data = build_payload(namespace, method, payload, self.key, mc.MANUFACTURER, header[mc.KEY_MESSAGEID])
-        print(f"Emulator({self.descriptor.uuid}) TX: namespace={namespace} method={method} payload={json_dumps(payload)}")
+        data = build_payload(
+            namespace,
+            method,
+            payload,
+            self.key,
+            mc.MANUFACTURER,
+            header[mc.KEY_MESSAGEID],
+        )
+        print(
+            f"Emulator({self.descriptor.uuid}) TX: namespace={namespace} method={method} payload={json_dumps(payload)}"
+        )
         return data
+
+    def update_epoch(self):
+        self.epoch = int(time())
+        if self.p_all_system_time is not None:
+            self.p_all_system_time[mc.KEY_TIMESTAMP] = self.epoch
 
     def _get_key_state(self, namespace: str) -> tuple[str, dict]:
         """
@@ -83,8 +115,8 @@ class MerossEmulator:
         For some devices not all state is carried there tho, so we'll inspect the
         GETACK payload for the relevant namespace looking for state there too
         """
-        n = namespace.split('.')
-        if n[1] != 'Control':
+        n = namespace.split(".")
+        if n[1] != "Control":
             raise Exception(f"{namespace} not supported in emulator")
 
         key = get_namespacekey(namespace)
@@ -119,9 +151,9 @@ class MerossEmulator:
             if (method == mc.METHOD_GET) and (namespace in self.descriptor.namespaces):
                 return mc.METHOD_GETACK, self.descriptor.namespaces[namespace]
             raise error
-        
+
         if method == mc.METHOD_GET:
-            return mc.METHOD_GETACK, { key: p_state }
+            return mc.METHOD_GETACK, {key: p_state}
 
         if method != mc.METHOD_SET:
             # TODO.....
@@ -147,7 +179,9 @@ class MerossEmulator:
             if p_state[mc.KEY_CHANNEL] == p_payload[mc.KEY_CHANNEL]:
                 p_state.update(p_payload)
             else:
-                raise Exception(f"{p_payload[mc.KEY_CHANNEL]} not present in digest.{key}")
+                raise Exception(
+                    f"{p_payload[mc.KEY_CHANNEL]} not present in digest.{key}"
+                )
 
         return mc.METHOD_SETACK, {}
 
@@ -169,12 +203,14 @@ class MerossEmulator:
     def _GET_Appliance_Control_Toggle(self, header, payload):
         # only acual example of this usage comes from legacy firmwares
         # carrying state in all->control
-        return mc.METHOD_GETACK, { mc.KEY_TOGGLE: self._get_control_key(mc.KEY_TOGGLE) }
+        return mc.METHOD_GETACK, {mc.KEY_TOGGLE: self._get_control_key(mc.KEY_TOGGLE)}
 
     def _SET_Appliance_Control_Toggle(self, header, payload):
         # only acual example of this usage comes from legacy firmwares
         # carrying state in all->control
-        self._get_control_key(mc.KEY_TOGGLE)[mc.KEY_ONOFF] = payload[mc.KEY_TOGGLE][mc.KEY_ONOFF]
+        self._get_control_key(mc.KEY_TOGGLE)[mc.KEY_ONOFF] = payload[mc.KEY_TOGGLE][
+            mc.KEY_ONOFF
+        ]
         return mc.METHOD_SETACK, {}
 
     def _SET_Appliance_Control_Light(self, header, payload):
@@ -199,7 +235,9 @@ class MerossEmulator:
 
     def _SET_Appliance_Control_Mp3(self, header, payload):
         if mc.NS_APPLIANCE_CONTROL_MP3 not in self.descriptor.namespaces:
-            raise Exception(f"{mc.NS_APPLIANCE_CONTROL_MP3} not supported in namespaces")
+            raise Exception(
+                f"{mc.NS_APPLIANCE_CONTROL_MP3} not supported in namespaces"
+            )
         mp3 = self.descriptor.namespaces[mc.NS_APPLIANCE_CONTROL_MP3]
         mp3[mc.KEY_MP3].update(payload[mc.KEY_MP3])
         return mc.METHOD_SETACK, {}

--- a/custom_components/meross_lan/emulator/mixins/electricity.py
+++ b/custom_components/meross_lan/emulator/mixins/electricity.py
@@ -1,0 +1,152 @@
+""""""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from random import randint
+from time import gmtime, mktime
+import typing
+
+from custom_components.meross_lan.merossclient import const as mc
+
+from ..emulator import MerossEmulator, MerossEmulatorDescriptor
+
+
+class ElectricityMixin(MerossEmulator if typing.TYPE_CHECKING else object):
+    def __init__(self, descriptor: MerossEmulatorDescriptor, key):
+        super().__init__(descriptor, key)
+        self.payload_electricity = descriptor.namespaces[
+            mc.NS_APPLIANCE_CONTROL_ELECTRICITY
+        ]
+        self.electricity = self.payload_electricity[mc.KEY_ELECTRICITY]
+        self.voltage_average: int = self.electricity[mc.KEY_VOLTAGE] or 2280
+        self.power = self.electricity[mc.KEY_POWER]
+
+    def _GET_Appliance_Control_Electricity(self, header, payload):
+        """
+        {
+            "electricity": {
+                "channel":0,
+                "current":34,
+                "voltage":2274,
+                "power":1015,
+                "config":{"voltageRatio":188,"electricityRatio":100}
+            }
+        }
+        """
+        p_electricity = self.electricity
+        power: int = p_electricity[mc.KEY_POWER]  # power in mW
+        if randint(0, 5) == 0:
+            # make a big power step
+            power += randint(-1000000, 1000000)
+        else:
+            # make some noise
+            power += randint(-1000, 1000)
+
+        if power > 3600000:
+            p_electricity[mc.KEY_POWER] = self.power = 3600000
+        elif power < 0:
+            p_electricity[mc.KEY_POWER] = self.power = 0
+        else:
+            p_electricity[mc.KEY_POWER] = self.power = int(power)
+
+        p_electricity[mc.KEY_VOLTAGE] = self.voltage_average + randint(-20, 20)
+        p_electricity[mc.KEY_CURRENT] = int(
+            10 * self.power / p_electricity[mc.KEY_VOLTAGE]
+        )
+        return mc.METHOD_GETACK, self.payload_electricity
+
+
+class ConsumptionMixin(MerossEmulator if typing.TYPE_CHECKING else object):
+
+    # this is a static default but we're likely using
+    # the current 'power' state managed by the ElectricityMixin
+    power = 0.0  # in mW
+    energy = 0.0  # in Wh
+    epoch_prev: int
+    power_prev = 0.0
+
+    BUG_RESET = True
+
+    def __init__(self, descriptor: MerossEmulatorDescriptor, key):
+        super().__init__(descriptor, key)
+        self.payload_consumptionx = descriptor.namespaces[
+            mc.NS_APPLIANCE_CONTROL_CONSUMPTIONX
+        ]
+        p_consumptionx: list = self.payload_consumptionx[mc.KEY_CONSUMPTIONX]
+        if (consumptionx_len := len(p_consumptionx)) == 0:
+            p_consumptionx.append(
+                {
+                    mc.KEY_DATE: "1970-01-01",
+                    mc.KEY_TIME: 0,
+                    mc.KEY_VALUE: 1,
+                }
+            )
+        else:
+
+            def _get_timestamp(consumptionx_item):
+                return consumptionx_item[mc.KEY_TIME]
+
+            p_consumptionx = sorted(p_consumptionx, key=_get_timestamp)
+            self.payload_consumptionx[mc.KEY_CONSUMPTIONX] = p_consumptionx
+
+        self.consumptionx = p_consumptionx
+        self.epoch_prev = self.epoch
+        # REMOVE
+        # "Asia/Bangkok" GMT + 7
+        # "Asia/Baku" GMT + 4
+        descriptor.timezone = descriptor.time[mc.KEY_TIMEZONE] = "Asia/Baku"
+
+    def _GET_Appliance_Control_ConsumptionX(self, header, payload):
+        """
+        {
+            "consumptionx": [
+                {"date":"2023-03-01","time":1677711486,"value":52},
+                {"date":"2023-03-02","time":1677797884,"value":53},
+                {"date":"2023-03-03","time":1677884282,"value":51},
+                ...
+            ]
+        }
+        """
+        # energy will be reset every time we update our consumptionx array
+        self.energy += (
+            (self.power + self.power_prev) * (self.epoch - self.epoch_prev) / 7200000
+        )
+        self.epoch_prev = self.epoch
+        self.power_prev = self.power
+
+        if self.energy < 1.0:
+            return mc.METHOD_GETACK, self.payload_consumptionx
+
+        energy = int(self.energy)
+        self.energy -= energy
+
+        y, m, d, hh, mm, ss, weekday, jday, dst = gmtime(self.epoch)
+        ss = min(ss, 59)  # clamp out leap seconds if the platform has them
+        devtime = datetime(y, m, d, hh, mm, ss, 0, timezone.utc)
+        if (tzinfo := self.tzinfo) is not None:  # REMOVE
+            devtime = devtime.astimezone(tzinfo)
+
+        date_value = "{:04d}-{:02d}-{:02d}".format(
+            devtime.year, devtime.month, devtime.day
+        )
+
+        p_consumptionx = self.consumptionx
+        consumptionx_last = p_consumptionx[-1]
+        if consumptionx_last[mc.KEY_DATE] != date_value:
+            if len(p_consumptionx) >= 30:
+                p_consumptionx.pop(0)
+            p_consumptionx.append(
+                {
+                    mc.KEY_DATE: date_value,
+                    mc.KEY_TIME: self.epoch,
+                    mc.KEY_VALUE: energy + consumptionx_last[mc.KEY_VALUE]
+                    if self.BUG_RESET
+                    else 0,
+                }
+            )
+
+        else:
+            consumptionx_last[mc.KEY_TIME] = self.epoch
+            consumptionx_last[mc.KEY_VALUE] += energy
+
+        return mc.METHOD_GETACK, self.payload_consumptionx

--- a/custom_components/meross_lan/emulator/mixins/garagedoor.py
+++ b/custom_components/meross_lan/emulator/mixins/garagedoor.py
@@ -1,20 +1,24 @@
 """"""
 from __future__ import annotations
-import typing
+
 import asyncio
-from ..emulator import MerossEmulator # pylint: disable=relative-beyond-top-level
-from ...merossclient import const as mc, get_element_by_key # pylint: disable=relative-beyond-top-level
+import typing
+
+from custom_components.meross_lan.merossclient import const as mc, get_element_by_key
+
+from ..emulator import MerossEmulator
 
 
 class GarageDoorMixin(MerossEmulator if typing.TYPE_CHECKING else object):
-
     def _SET_Appliance_GarageDoor_Config(self, header, payload):
-        p_config = self.descriptor.namespaces[mc.NS_APPLIANCE_GARAGEDOOR_CONFIG][mc.KEY_CONFIG]
+        p_config = self.descriptor.namespaces[mc.NS_APPLIANCE_GARAGEDOOR_CONFIG][
+            mc.KEY_CONFIG
+        ]
         p_request = payload[mc.KEY_CONFIG]
         for _key, _value in p_request.items():
             if _key in p_config:
                 p_config[_key] = _value
-        return mc.METHOD_SETACK, { }
+        return mc.METHOD_SETACK, {}
 
     def _GET_Appliance_GarageDoor_State(self, header, payload):
         # return everything...at the moment we always query all
@@ -22,9 +26,9 @@ class GarageDoorMixin(MerossEmulator if typing.TYPE_CHECKING else object):
         if len(p_garageDoor) == 1:
             # un-pack the list since real traces show no list
             # in this response payloads (we only have msg100 so far..)
-            return mc.METHOD_GETACK, { mc.KEY_STATE: p_garageDoor[0] }
+            return mc.METHOD_GETACK, {mc.KEY_STATE: p_garageDoor[0]}
         else:
-            return mc.METHOD_GETACK, { mc.KEY_STATE: p_garageDoor }
+            return mc.METHOD_GETACK, {mc.KEY_STATE: p_garageDoor}
 
     def _SET_Appliance_GarageDoor_State(self, header, payload):
         p_request = payload[mc.KEY_STATE]
@@ -33,9 +37,7 @@ class GarageDoorMixin(MerossEmulator if typing.TYPE_CHECKING else object):
         p_digest = self.descriptor.digest
 
         p_state = get_element_by_key(
-            p_digest[mc.KEY_GARAGEDOOR],
-            mc.KEY_CHANNEL,
-            request_channel
+            p_digest[mc.KEY_GARAGEDOOR], mc.KEY_CHANNEL, request_channel
         )
 
         p_response = dict(p_state)
@@ -48,5 +50,4 @@ class GarageDoorMixin(MerossEmulator if typing.TYPE_CHECKING else object):
             loop.call_later(2 if request_open else 10, _state_update_callback)
 
         p_response[mc.KEY_EXECUTE] = 1
-        return mc.METHOD_SETACK, { mc.KEY_STATE: p_response }
-
+        return mc.METHOD_SETACK, {mc.KEY_STATE: p_response}

--- a/custom_components/meross_lan/emulator/mixins/thermostat.py
+++ b/custom_components/meross_lan/emulator/mixins/thermostat.py
@@ -1,12 +1,14 @@
 """"""
 from __future__ import annotations
+
 import typing
-from ..emulator import MerossEmulator # pylint: disable=relative-beyond-top-level
-from ...merossclient import const as mc, get_element_by_key # pylint: disable=relative-beyond-top-level
+
+from custom_components.meross_lan.merossclient import const as mc, get_element_by_key
+
+from ..emulator import MerossEmulator
 
 
 class ThermostatMixin(MerossEmulator if typing.TYPE_CHECKING else object):
-
     def _SET_Appliance_Control_Thermostat_Mode(self, header, payload):
         p_digest = self.descriptor.digest
         p_digest_mode_list = p_digest[mc.KEY_THERMOSTAT][mc.KEY_MODE]
@@ -15,9 +17,7 @@ class ThermostatMixin(MerossEmulator if typing.TYPE_CHECKING else object):
         for p_mode in p_mode_list:
             channel = p_mode[mc.KEY_CHANNEL]
             p_digest_mode = get_element_by_key(
-                p_digest_mode_list,
-                mc.KEY_CHANNEL,
-                channel
+                p_digest_mode_list, mc.KEY_CHANNEL, channel
             )
             p_digest_mode.update(p_mode)
             mode = p_digest_mode[mc.KEY_MODE]
@@ -25,21 +25,30 @@ class ThermostatMixin(MerossEmulator if typing.TYPE_CHECKING else object):
                 mc.MTS200_MODE_HEAT: mc.KEY_HEATTEMP,
                 mc.MTS200_MODE_COOL: mc.KEY_COOLTEMP,
                 mc.MTS200_MODE_ECO: mc.KEY_ECOTEMP,
-                mc.MTS200_MODE_CUSTOM: mc.KEY_MANUALTEMP
+                mc.MTS200_MODE_CUSTOM: mc.KEY_MANUALTEMP,
             }
             if mode in MODE_KEY_MAP:
                 p_digest_mode[mc.KEY_TARGETTEMP] = p_digest_mode[MODE_KEY_MAP[mode]]
-            else:# we use this to trigger a windowOpened later in code
-                p_digest_windowopened_list = p_digest[mc.KEY_THERMOSTAT][mc.KEY_WINDOWOPENED]
+            else:  # we use this to trigger a windowOpened later in code
+                p_digest_windowopened_list = p_digest[mc.KEY_THERMOSTAT][
+                    mc.KEY_WINDOWOPENED
+                ]
             if p_digest_mode[mc.KEY_ONOFF]:
-                p_digest_mode[mc.KEY_STATE] = 1 if p_digest_mode[mc.KEY_TARGETTEMP] > p_digest_mode[mc.KEY_CURRENTTEMP] else 0
+                p_digest_mode[mc.KEY_STATE] = (
+                    1
+                    if p_digest_mode[mc.KEY_TARGETTEMP]
+                    > p_digest_mode[mc.KEY_CURRENTTEMP]
+                    else 0
+                )
             else:
                 p_digest_mode[mc.KEY_STATE] = 0
 
             # randomly switch the window
             for p_digest_windowopened in p_digest_windowopened_list:
                 if p_digest_windowopened[mc.KEY_CHANNEL] == channel:
-                    p_digest_windowopened[mc.KEY_STATUS] = 0 if p_digest_windowopened[mc.KEY_STATUS] else 1
+                    p_digest_windowopened[mc.KEY_STATUS] = (
+                        0 if p_digest_windowopened[mc.KEY_STATUS] else 1
+                    )
                     break
 
         return mc.METHOD_SETACK, {}

--- a/custom_components/meross_lan/manifest.json
+++ b/custom_components/meross_lan/manifest.json
@@ -1,22 +1,22 @@
 {
   "domain": "meross_lan",
   "name": "Meross LAN",
-  "integration_type": "hub",
+  "after_dependencies": ["mqtt", "dhcp", "recorder", "persistent_notification"],
+  "codeowners": ["@krahabb"],
   "config_flow": true,
-  "iot_class": "local_polling",
-  "documentation": "https://github.com/krahabb/meross_lan",
-  "issue_tracker": "https://github.com/krahabb/meross_lan/issues",
-  "requirements": [],
   "dhcp": [
     {"hostname": "*", "macaddress": "48E1E9*"},
     {"hostname": "*", "macaddress": "34298F1*"},
     {"registered_devices": true}
   ],
+  "documentation": "https://github.com/krahabb/meross_lan",
+  "integration_type": "hub",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/krahabb/meross_lan/issues",
+  "loggers": ["custom_components.meross_lan"],
   "mqtt": [
     "/appliance/+/publish"
   ],
-  "after_dependencies": ["mqtt", "dhcp", "recorder", "persistent_notification"],
-  "loggers": ["custom_components.meross_lan"],
-  "codeowners": ["@krahabb"],
-  "version": "3.0.2"
+  "requirements": [],
+  "version": "3.0.3"
 }

--- a/custom_components/meross_lan/meross_device.py
+++ b/custom_components/meross_lan/meross_device.py
@@ -147,6 +147,7 @@ class MerossDevice:
     _polling_delay: int = CONF_POLLING_PERIOD_DEFAULT
     # other default property values
     _deviceentry = None # weakly cached entry to the device registry
+    _tzinfo: ZoneInfo | None = None # smart cache of device tzinfo
 
     def __init__(
         self,
@@ -163,7 +164,7 @@ class MerossDevice:
         self.needsave = (
             False  # while parsing ns.ALL code signals to persist ConfigEntry
         )
-        self.device_timestamp: int = 0
+        self.device_timestamp = 0.0
         self.device_timedelta = 0
         self.device_timedelta_log_epoch = 0
         self.device_timedelta_config_epoch = 0
@@ -252,31 +253,33 @@ class MerossDevice:
                 else:
                     _init(payload)
 
+    def __del__(self):
+        LOGGER.debug("MerossDevice(%s) destroy", self.device_id)
+        return
+
     def start(self):
-        # called by async_setup after the entities have been registered
+        # called by async_setup_entry after the entities have been registered
         # here we'll start polling after the states have been eventually
         # restored (some entities need this)
         self._unsub_polling_callback = self.api.schedule_async_callback(
             0, self._async_polling_callback
         )
 
-    def __del__(self):
-        LOGGER.debug("MerossDevice(%s) destroy", self.device_id)
-        return
-
-    def shutdown(self):
+    async def async_shutdown(self):
         """
         called when the config entry is unloaded
         we'll try to clear everything here
         """
-        if self._unsub_polling_callback is not None:
-            self._unsub_polling_callback.cancel()
-            self._unsub_polling_callback = None
-        if self._unsub_entry_update_listener is not None:
-            self._unsub_entry_update_listener()
-            self._unsub_entry_update_listener = None
-        if self._trace_file:
+        while self._unsub_polling_callback is None:
+            # wait for the polling loop to finish in case
+            await asyncio.sleep(1)
+        self._unsub_polling_callback.cancel()
+        self._unsub_polling_callback = None
+        self._unsub_entry_update_listener()
+        if self._trace_file is not None:
             self._trace_close()
+        self.entities.clear()
+        self.entity_dnd = MerossFakeEntity
 
     @property
     def host(self):
@@ -289,8 +292,13 @@ class MerossDevice:
     @property
     def tzinfo(self) -> tzinfo:
         tz_name = self.descriptor.timezone
+        if not tz_name:
+            return timezone.utc
+        if (self._tzinfo is not None) and (self._tzinfo.key == tz_name):
+            return self._tzinfo
         try:
-            return ZoneInfo(tz_name) if tz_name else timezone.utc
+            self._tzinfo = ZoneInfo(tz_name)
+            return self._tzinfo
         except Exception:
             self.log(
                 WARNING,
@@ -299,7 +307,8 @@ class MerossDevice:
                 self.name,
                 tz_name,
             )
-            return timezone.utc
+            self._tzinfo = None
+        return timezone.utc
 
     @property
     def name(self) -> str:
@@ -331,7 +340,7 @@ class MerossDevice:
         # We ignore delays below PARAM_TIMESTAMP_TOLERANCE since
         # we'll always be a bit late in processing
         epoch = time()
-        self.device_timestamp = int(header.get(mc.KEY_TIMESTAMP, epoch))
+        self.device_timestamp = float(header.get(mc.KEY_TIMESTAMP, epoch))
         device_timedelta = epoch - self.device_timestamp
         if abs(device_timedelta) > PARAM_TIMESTAMP_TOLERANCE:
             self._config_timestamp(epoch, device_timedelta)
@@ -365,9 +374,7 @@ class MerossDevice:
 
         self.lastupdate = epoch
         if not self._online:
-            self.log(DEBUG, 0, "MerossDevice(%s) back online!", self.name)
-            self._online = True
-            self._polling_delay = self.polling_period
+            self._set_online()
             self.api.hass.async_create_task(
                 self.async_request_updates(epoch, namespace)
             )
@@ -694,6 +701,7 @@ class MerossDevice:
     async def _async_polling_callback(self):
         LOGGER.log(DEBUG, "MerossDevice(%s) polling start", self.name)
         try:
+            self._unsub_polling_callback = None
             epoch = time()
             # this is a kind of 'heartbeat' to check if the device is still there
             # especially on MQTT where we might see no messages for a long time
@@ -999,6 +1007,23 @@ class MerossDevice:
                     mc.METHOD_SET,
                     payload={mc.KEY_TIME: {mc.KEY_TIMEZONE: "", mc.KEY_TIMERULE: []}},
                 )
+
+    def _set_online(self):
+        self.log(DEBUG, 0, "MerossDevice(%s) back online!", self.name)
+        self._online = True
+        self._polling_delay = self.polling_period
+        # retrigger the polling loop since we're already
+        # scheduling an immediate async_request_updates.
+        # This is needed to avoid startup staggering and also
+        # as an optimization against asynchronous onlining events (on MQTT)
+        # which could come anytime and so the (next)
+        # polling might be too early
+        if self._unsub_polling_callback is not None:
+            # might be None when we're already inside a polling loop
+            self._unsub_polling_callback.cancel()
+            self._unsub_polling_callback = self.api.schedule_async_callback(
+                self._polling_delay, self._async_polling_callback
+            )
 
     def _set_offline(self):
         self.log(DEBUG, 0, "MerossDevice(%s) going offline!", self.name)

--- a/custom_components/meross_lan/meross_device.py
+++ b/custom_components/meross_lan/meross_device.py
@@ -367,6 +367,7 @@ class MerossDevice:
         if not self._online:
             self.log(DEBUG, 0, "MerossDevice(%s) back online!", self.name)
             self._online = True
+            self._polling_delay = self.polling_period
             self.api.hass.async_create_task(
                 self.async_request_updates(epoch, namespace)
             )
@@ -551,7 +552,7 @@ class MerossDevice:
             _httpclient: MerossHttpClient = getattr(self, VOLATILE_ATTR_HTTPCLIENT, None)  # type: ignore
             if _httpclient is None:
                 _httpclient = MerossHttpClient(
-                    self.host, self.key, async_get_clientsession(self.api.hass), LOGGER
+                    self.host, self.key, async_get_clientsession(self.api.hass), LOGGER  # type: ignore
                 )
                 self._httpclient = _httpclient
 

--- a/custom_components/meross_lan/meross_device.py
+++ b/custom_components/meross_lan/meross_device.py
@@ -252,7 +252,11 @@ class MerossDevice:
                 else:
                     _init(payload)
 
-        self._unsub_polling_callback = api.schedule_async_callback(
+    def start(self):
+        # called by async_setup after the entities have been registered
+        # here we'll start polling after the states have been eventually
+        # restored (some entities need this)
+        self._unsub_polling_callback = self.api.schedule_async_callback(
             0, self._async_polling_callback
         )
 

--- a/custom_components/meross_lan/sensor.py
+++ b/custom_components/meross_lan/sensor.py
@@ -294,14 +294,14 @@ class ElectricityMixin(
         super().start()
 
     def shutdown(self):
-        if self._cancel_energy_reset is not None:
-            self._cancel_energy_reset()
-            self._cancel_energy_reset = None
+        super().shutdown()
         self._sensor_power = None  # type: ignore
         self._sensor_current = None  # type: ignore
         self._sensor_voltage = None  # type: ignore
         self._sensor_energy_estimate = None  # type: ignore
-        super().shutdown()
+        if self._cancel_energy_reset is not None:
+            self._cancel_energy_reset()
+            self._cancel_energy_reset = None
 
     def _handle_Appliance_Control_Electricity(self, header: dict, payload: dict):
         electricity = payload[mc.KEY_ELECTRICITY]
@@ -394,8 +394,8 @@ class ConsumptionMixin(
         self._sensor_energy = EnergySensor(self, DEVICE_CLASS_ENERGY)
 
     def shutdown(self):
-        self._sensor_energy = None  # type: ignore
         super().shutdown()
+        self._sensor_energy = None  # type: ignore
 
     def _handle_Appliance_Control_ConsumptionX(self, header: dict, payload: dict):
         self._energy_lastupdate = self.lastupdate
@@ -515,6 +515,7 @@ class RuntimeMixin(
     MerossDevice if typing.TYPE_CHECKING else object
 ):  # pylint: disable=used-before-assignment
 
+    _sensor_runtime: MLSensor
     _lastupdate_runtime = 0
 
     def __init__(self, api, descriptor: MerossDeviceDescriptor, entry):
@@ -528,6 +529,10 @@ class RuntimeMixin(
         self._sensor_runtime._attr_entity_category = me.EntityCategory.DIAGNOSTIC
         self._sensor_runtime._attr_native_unit_of_measurement = PERCENTAGE
         self._sensor_runtime._attr_icon = "mdi:wifi"
+
+    def shutdown(self):
+        super().shutdown()
+        self._sensor_runtime = None  # type: ignore
 
     def _handle_Appliance_System_Runtime(self, header: dict, payload: dict):
         self._lastupdate_runtime = self.lastupdate


### PR DESCRIPTION
This is mainly a maintenance release fixing some known (and some less known) bugs and adding some news (both fixes and improvements) on the energy consumption sensor available on some plugs (mss310 and the likes)

# features
- added an 'energy_estimate' sensor to devices reporting power consumption. This sensor computes the energy consumption (Wh) for the current day (it then resets at midnight in HA local time) by implementing the sum on the device measured actual power. This is different from the 'legacy' sensor in the fact that energy accumulation is done at the HA level in meross_lan and not in the device. This sensor is initially disabled on initial configuration so you'll not see that in the standard user UI. Check https://github.com/krahabb/meross_lan/issues/264#issuecomment-1465788298 for details

# fixes
- MTS200 payload formatting (#259)
- energy consumption failing to reset at midnight (#264)
- a bug in polling which could increase the polling interval well over the configured value under some ciscumstances (after a device disconnection)
- various bugs in device de-initialization (they happen when HA stops or when you reload a configuration entry so they're usually no harm or hardly impacting any installation)