### PR TITLE
Fix entities name and remove useless info

### DIFF
--- a/custom_components/meross_lan/meross_entity.py
+++ b/custom_components/meross_lan/meross_entity.py
@@ -121,10 +121,16 @@ class MerossEntity(Loggable, Entity if typing.TYPE_CHECKING else object):
         self.manager = manager
         self.channel = channel
         self._attr_device_class = device_class
-        if self._attr_name is None:
-            self._attr_name = f"{entitykey or device_class}"
-        if channel:  # when channel == 0 it might be the only one so skip it
-            self._attr_name = f"{self._attr_name} {channel}"
+        attr_name = self._attr_name
+        if attr_name is None and (entitykey or device_class):
+            attr_name = f"{entitykey or device_class}"
+        # when channel == 0 it might be the only one so skip it
+        # when channel is already in device name it also may be skipped
+        if channel and manager.name.find(str(channel)) == -1:
+            attr_name = f"{attr_name} {channel}" if attr_name else str(channel)
+        if attr_name is not None:
+            attr_name = attr_name.capitalize()
+        self._attr_name = attr_name
         self._attr_state = None
         self._attr_unique_id = manager.generate_unique_id(self)
         self._hass_connected = False


### PR DESCRIPTION
Scope of this PR is to improve a little bit the way in which entity name are generated to simplify device / entities renaming.
I have 5 `mts100v3` smart valves connected via a `msh300` smart hub. When the valves are added to HA a name like this is generated:

- Device Name: `Smart Thermostat (01008602)`
- entity id: `climate.smart_thermostat_01008602_none_01008602`
- entity friendly name: `None 01008602`

(same for all other sensors associated, just None is replaced by the name of the sensor)

With this PR the following logic is implemented:

1) if both `entitykey` and `device_class` are None, they are not used for `_attr_name` (this because `f"{None}"` return the string `"None"`)
2) if the channel is already in device name (`manager.name`), it is not added at the end of the entity name (one time is enough to make it unique)
3) finally the entity name is capitalized to be compliant with [HA Entity Naming](https://developers.home-assistant.io/docs/core/entity?_highlight=has_ent#has_entity_name-true-mandatory-for-new-integrations)

This change should not create any issue to already configured entity because `unique_id` is unchanged.

And thanks a lot for this great integration🎉
