### PR TITLE
Release Cloudy.5.2

### DIFF
--- a/custom_components/meross_lan/config_flow.py
+++ b/custom_components/meross_lan/config_flow.py
@@ -50,6 +50,9 @@ class ConfigError(Exception):
 class MerossFlowHandlerMixin(FlowHandler if typing.TYPE_CHECKING else object):
     """Mixin providing commons for Config and Option flows"""
 
+    VERSION = 1
+    MINOR_VERSION = 1
+
     # this is set for an OptionsFlow
     _profile_entry: config_entries.ConfigEntry | None = None
 
@@ -144,6 +147,7 @@ class MerossFlowHandlerMixin(FlowHandler if typing.TYPE_CHECKING else object):
                         await helper.config_entries.async_add(
                             config_entries.ConfigEntry(
                                 version=self.VERSION,
+                                minor_version=self.MINOR_VERSION,
                                 domain=mlc.DOMAIN,
                                 title=profile_config[mc.KEY_EMAIL],
                                 data=profile_config,
@@ -332,8 +336,6 @@ class MerossFlowHandlerMixin(FlowHandler if typing.TYPE_CHECKING else object):
 
 class ConfigFlow(MerossFlowHandlerMixin, config_entries.ConfigFlow, domain=mlc.DOMAIN):
     """Handle a config flow for Meross IoT local LAN."""
-
-    VERSION = 1
 
     _MENU_USER = {
         "step_id": "user",

--- a/custom_components/meross_lan/cover.py
+++ b/custom_components/meross_lan/cover.py
@@ -15,7 +15,7 @@ from homeassistant.components.cover import (
     CoverDeviceClass,
     CoverEntityFeature,
 )
-from homeassistant.const import TIME_SECONDS
+from homeassistant.const import UnitOfTime
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry
 from homeassistant.util.dt import now
@@ -199,7 +199,7 @@ class MLGarageMultipleConfigNumber(MLConfigNumber):
 
     @property
     def native_unit_of_measurement(self):
-        return TIME_SECONDS
+        return UnitOfTime.SECONDS
 
     @property
     def device_scale(self):
@@ -1049,7 +1049,7 @@ class MLRollerShutterConfigNumber(MLConfigNumber):
 
     @property
     def native_unit_of_measurement(self):
-        return TIME_SECONDS
+        return UnitOfTime.SECONDS
 
     @property
     def device_scale(self):

--- a/custom_components/meross_lan/helpers.py
+++ b/custom_components/meross_lan/helpers.py
@@ -559,7 +559,7 @@ class Loggable(abc.ABC):
         self.id = id
         self.logtag = logtag or f"{self.__class__.__name__}({id})"
         self.logger = logger
-        logger.debug("%s: init", self.logtag)
+        LOGGER.debug("%s: init", self.logtag)
 
     def isEnabledFor(self, level: int):
         return self.logger.isEnabledFor(level)
@@ -610,7 +610,7 @@ class Loggable(abc.ABC):
             )
 
     def __del__(self):
-        self.logger.debug("%s: destroy", self.logtag)
+        LOGGER.debug("%s: destroy", self.logtag)
         return
 
 

--- a/custom_components/meross_lan/manifest.json
+++ b/custom_components/meross_lan/manifest.json
@@ -18,5 +18,5 @@
     "/appliance/+/publish"
   ],
   "requirements": [],
-  "version": "4.5.1"
+  "version": "4.5.2"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@ scapy
 janus
 fnv-hash-fast
 psutil-home-assistant
-pytest-homeassistant-custom-component==0.13.76
+pytest-homeassistant-custom-component @ git+https://github.com/MatthewFlamm/pytest-homeassistant-custom-component@0.13.87

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,6 @@ scapy
 janus
 fnv-hash-fast
 psutil-home-assistant
-pytest-homeassistant-custom-component @ git+https://github.com/MatthewFlamm/pytest-homeassistant-custom-component@0.13.87
+#pytest-homeassistant-custom-component==0.13.42 # HA core 2023.7.0
+#pytest-homeassistant-custom-component==0.13.85 # HA core 2023.12.3
+pytest-homeassistant-custom-component @ git+https://github.com/MatthewFlamm/pytest-homeassistant-custom-component@0.13.87 # HA core 2024.1.0

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -13,11 +13,11 @@ from unittest.mock import MagicMock, Mock, patch
 
 import aiohttp
 from freezegun.api import FrozenDateTimeFactory, StepTickTimeFactory, freeze_time
-from homeassistant import config_entries
+from homeassistant import config_entries, const as hac
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 from pytest_homeassistant_custom_component.common import (
-    MockConfigEntry,
+    MockConfigEntry,  # type: ignore
     async_fire_time_changed_exact,
 )
 from pytest_homeassistant_custom_component.test_util.aiohttp import (
@@ -32,6 +32,31 @@ from custom_components.meross_lan.merossclient import cloudapi, const as mc
 from emulator import MerossEmulator, build_emulator as emulator_build_emulator
 
 from . import const as tc
+
+
+class MockConfigEntry(MockConfigEntry):
+    """
+    compatibility layer for changing MockConfigEntry signatures between
+    HA core 2023.latest and 2024.1
+    """
+    def __init__(
+        self,
+        *,
+        domain: str,
+        data,
+        version: int,
+        minor_version: int,
+        unique_id: str,
+    ):
+        kwargs = {
+            "domain": domain,
+            "data": data,
+            "version": version,
+            "unique_id": unique_id,
+        }
+        if hac.MAJOR_VERSION >= 2024:
+            kwargs["minor_version"] = minor_version
+        super().__init__(**kwargs)
 
 
 class ConfigEntryMocker(contextlib.AbstractAsyncContextManager):
@@ -226,8 +251,9 @@ def build_emulator_config_entry(
     return MockConfigEntry(
         domain=mlc.DOMAIN,
         data=data,
+        version=ConfigFlow.VERSION,
+        minor_version=ConfigFlow.MINOR_VERSION,
         unique_id=data[mlc.CONF_DEVICE_ID],
-        version=1,
     )
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -26,6 +26,7 @@ from pytest_homeassistant_custom_component.test_util.aiohttp import (
 )
 
 from custom_components.meross_lan import MerossApi, MerossDevice, const as mlc
+from custom_components.meross_lan.config_flow import ConfigFlow
 from custom_components.meross_lan.meross_profile import MerossMQTTConnection
 from custom_components.meross_lan.merossclient import cloudapi, const as mc
 from emulator import MerossEmulator, build_emulator as emulator_build_emulator
@@ -39,7 +40,7 @@ class ConfigEntryMocker(contextlib.AbstractAsyncContextManager):
         hass: HomeAssistant,
         unique_id: str,
         *,
-        data: dict | None = None,
+        data: Any | None = None,
         auto_add: bool = True,
         auto_setup: bool = True,
     ) -> None:
@@ -48,6 +49,8 @@ class ConfigEntryMocker(contextlib.AbstractAsyncContextManager):
         self.config_entry = MockConfigEntry(
             domain=mlc.DOMAIN,
             data=data,
+            version=ConfigFlow.VERSION,
+            minor_version=ConfigFlow.MINOR_VERSION,
             unique_id=unique_id,
         )
         self.auto_setup = auto_setup


### PR DESCRIPTION
fixes:
- error in parsing garageDoor payload #361
- update deprecated TIME_SECONDS unit #362
- ConfigEntry compatibility in 2024.1 #365
- better error management (checks for device key error) in MQTT device identification (OptionsFlow)