### PR TITLE
Remove unignore flow

### DIFF
--- a/custom_components/meross_lan/config_flow.py
+++ b/custom_components/meross_lan/config_flow.py
@@ -580,17 +580,6 @@ class ConfigFlow(MerossFlowHandlerMixin, ce.ConfigFlow, domain=mlc.DOMAIN):
             menu_options=["profile", "device"],
         )
 
-    async def async_step_unignore(self, user_input):
-        """Rediscover a config entry by it's unique_id."""
-        match ConfigEntryType.get_type_and_id(user_input["unique_id"]):
-            case (ConfigEntryType.DEVICE, mac_address_fmt):
-                if mac_address_fmt in ConfigFlow.DHCP_DISCOVERIES:
-                    return await self.async_step_dhcp(
-                        ConfigFlow.DHCP_DISCOVERIES.pop(mac_address_fmt)
-                    )
-
-        return self.async_abort()
-
     async def async_step_hub(self, user_input=None):
         """configure the MQTT discovery device key"""
         if user_input is not None:


### PR DESCRIPTION
The unignore flow is no longer supported by Home Assistant core with merge of https://github.com/home-assistant/core/pull/126765, the DHCP integration will reinitialize discovery when a config entry is removed thanks to https://github.com/home-assistant/core/pull/126556