### PR TITLE
Fix light transition ZeroDivisionError error

### DIFF
--- a/custom_components/meross_lan/light.py
+++ b/custom_components/meross_lan/light.py
@@ -562,7 +562,7 @@ class MLLight(MLLightBase):
 
         _light = dict(self._light)
 
-        if ATTR_TRANSITION in kwargs:
+        if ATTR_TRANSITION in kwargs and kwargs[ATTR_TRANSITION] != 0:
             _t_duration = self._transition_setup(_light, kwargs)
             if self._t_rgb_end:
                 _light[mc.KEY_CAPACITY] = mc.LIGHT_CAPACITY_RGB_LUMINANCE


### PR DESCRIPTION
This fixes an issue where the integration would error if transition is specified but set to zero. For example:
```yaml
action: light.turn_on
target:
  device_id: ...
data:
  transition: 0 # This is what's causing the issue. Omitting this line fixes the error.
```

<details>
<summary>
Full error message
</summary>


```
Logger: homeassistant.helpers.script.websocket_api_script
Source: helpers/script.py:526
First occurred: 10:06:11 PM (1 occurrences)
Last logged: 10:06:11 PM

websocket_api script: Error executing script. Unexpected error for call_service at pos 1: float division by zero
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 526, in _async_step
    await getattr(self, handler)()
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 764, in _async_call_service_step
    response_data = await self._async_run_long_action(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<9 lines>...
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 727, in _async_run_long_action
    return await long_task
           ^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2802, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2845, in _execute_service
    return await target(service_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 1007, in entity_service_call
    single_response = await _handle_entity_call(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
        hass, entity, func, data, call.context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 1079, in _handle_entity_call
    result = await task
             ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/light/__init__.py", line 628, in async_handle_light_on_service
    await light.async_turn_on(**filter_turn_on_params(light, params))
  File "/config/custom_components/meross_lan/light.py", line 566, in async_turn_on
    _t_duration = self._transition_setup(_light, kwargs)
  File "/config/custom_components/meross_lan/light.py", line 327, in _transition_setup
    self._t_luminance_r = (
                          ~
        self._t_luminance_end - self._t_luminance_begin
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ) / _t_duration
    ~~^~~~~~~~~~~~~
ZeroDivisionError: float division by zero
```
</details>

I just added a simple check which will treat `0` the same as not specifying the transition at all, which fixes the error.