### PR TITLE
Fix: compatibility with Home Assistant 2025.11 (CoverState constants …

### DIFF
--- a/custom_components/meross_lan/cover.py
+++ b/custom_components/meross_lan/cover.py
@@ -1,6 +1,19 @@
 import typing
 
 from homeassistant.components import cover
+from homeassistant.components.cover import CoverState  # new enum in HA 2025.11+
+
+# Backfill removed STATE_* constants so existing code keeps working
+# (HA 2025.11+ removed them in favor of CoverState)
+if not hasattr(cover, "STATE_OPEN"):
+    cover.STATE_OPEN = CoverState.OPEN
+if not hasattr(cover, "STATE_CLOSED"):
+    cover.STATE_CLOSED = CoverState.CLOSED
+if not hasattr(cover, "STATE_OPENING"):
+    cover.STATE_OPENING = CoverState.OPENING
+if not hasattr(cover, "STATE_CLOSING"):
+    cover.STATE_CLOSING = CoverState.CLOSING
+
 from homeassistant.exceptions import InvalidStateError
 
 from .const import CONF_PROTOCOL_HTTP, PARAM_ROLLERSHUTTER_TRANSITION_POLL_TIMEOUT


### PR DESCRIPTION
Home Assistant Core 2025.11 removed the legacy constants
cover.STATE_OPEN, STATE_CLOSED, STATE_OPENING, and STATE_CLOSING
in favor of the new CoverState enum.

Meross LAN (v5.6.0) still references these constants, which causes errors when any cover or garage-door device reports state changes.

This PR restores compatibility by importing CoverState and backfilling the removed constants on the cover module, allowing the integration to work unchanged across old and new Home Assistant versions.

**Problem**

After updating to HA 2025.11.x, repeated errors appear in the log:

```
AttributeError: module 'homeassistant.components.cover' has no attribute 'STATE_OPEN'
AttributeError: module 'homeassistant.components.cover' has no attribute 'STATE_CLOSED'
```


These originate from GarageDoorStateNamespaceHandler (for MSG100 devices) and any component referencing MLCover.ENTITY_COMPONENT.STATE_*.

**Solution**

Update the import and add a compatibility shim at the top of custom_components/meross_lan/cover.py:

```
from homeassistant.components import cover  # keep the module available
from homeassistant.components.cover import CoverState  # new enum in HA 2025.11+

# Backfill removed STATE_* constants so existing code keeps working
# (HA 2025.11+ removed them in favor of CoverState)
if not hasattr(cover, "STATE_OPEN"):
    cover.STATE_OPEN = CoverState.OPEN
if not hasattr(cover, "STATE_CLOSED"):
    cover.STATE_CLOSED = CoverState.CLOSED
if not hasattr(cover, "STATE_OPENING"):
    cover.STATE_OPENING = CoverState.OPENING
if not hasattr(cover, "STATE_CLOSING"):
    cover.STATE_CLOSING = CoverState.CLOSING
```


No other code changes required.

**Tested**

Verified on:

HA Core: 2025.11.1

Meross LAN: v5.6.0

Device: Meross MSG100 (garage door)

After applying the patch:

No more AttributeError in logs.

Garage door entity reports correct Open/Closed state and responds to commands normally.

**Notes**

This fix is fully backward-compatible with earlier HA versions.

Maintains the existing interface (MLCover.ENTITY_COMPONENT.STATE_*).

Provides a minimal, drop-in solution until full migration to CoverState is implemented internally.

Thanks for maintaining this fantastic integration! 