### PR TITLE
Fix deprecated Home Assistant device registry APIs

### DIFF
--- a/custom_components/meross_lan/devices/hub/__init__.py
+++ b/custom_components/meross_lan/devices/hub/__init__.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, override
 
+from homeassistant.helpers import device_registry as dr
+
 from ... import const as mlc
 from ...binary_sensor import MLBinarySensor
 from ...button import MLButton
@@ -591,7 +593,7 @@ class SubDevice(NamespaceParser, BaseDevice):
             logger=hub,
             name=get_productnameuuid(model, id),
             model=model,
-            via_device=next(iter(hub.deviceentry_id["identifiers"])),
+            via_device_id=hub.device_registry_entry.id,
         )
         self.platforms = hub.platforms
         hub.subdevices[id] = self
@@ -1446,10 +1448,8 @@ def digest_init_hub(device: "HubMixin", digest) -> "DigestInitReturnType":
 
     # Check for unbinded subdevices which are 'still' in the device_registry
     registry_subdevices = {}
-    for (
-        device_entry
-    ) in device.api.device_registry.devices.get_devices_for_config_entry_id(
-        device.config_entry.entry_id
+    for device_entry in dr.async_entries_for_config_entry(
+        device.api.device_registry, device.config_entry.entry_id
     ):
         # The caveat here is to detect if a subdev has been re-binded to
         # a different hub (so a different config_entry). We need to be sure

--- a/custom_components/meross_lan/helpers/device.py
+++ b/custom_components/meross_lan/helpers/device.py
@@ -113,7 +113,7 @@ class BaseDevice(EntityManager):
             hw_version: NotRequired[str]
             sw_version: NotRequired[str]
             connections: NotRequired[set[tuple[str, str]]]
-            via_device: NotRequired[tuple[str, str]]
+            via_device_id: NotRequired[str]
 
     __slots__ = (
         "online",
@@ -136,7 +136,7 @@ class BaseDevice(EntityManager):
             model=kwargs.get("model"),
             hw_version=kwargs.get("hw_version"),
             sw_version=kwargs.get("sw_version"),
-            via_device=kwargs.get("via_device"),
+            via_device_id=kwargs.get("via_device_id"),
             identifiers=identifiers,
         )
 


### PR DESCRIPTION
## Summary

Update `meross_lan` to use the current Home Assistant device registry APIs and
remove deprecation warnings introduced by recent Home Assistant releases.

## Changes

- Replace the deprecated `via_device` parameter with `via_device_id`.
- Link subdevices directly to the already-registered hub device ID.
- Replace mapping-style access to `device_registry.devices` with
  `dr.async_entries_for_config_entry(...)`.

## Compatibility

This change preserves the existing hub/subdevice relationship, device
identifiers, unique IDs, entities, polling behavior, and configuration flow.

## Validation

- Python compilation completed successfully.
- The patch was verified as idempotent locally.
- The resulting unified diff applies cleanly.
- After restarting Home Assistant, the related deprecation warnings no longer
  appear in the logs.

This addresses the Home Assistant device registry deprecations documented at:

https://developers.home-assistant.io/docs/device_registry_index/
