### PR TITLE
fix: add Home Assistant device registry compatibility

### DIFF
--- a/custom_components/meross_lan/helpers/device.py
+++ b/custom_components/meross_lan/helpers/device.py
@@ -1,6 +1,7 @@
 import abc
 import asyncio
 import bisect
+import inspect
 from datetime import UTC, tzinfo
 from json import JSONDecodeError
 from time import time
@@ -92,6 +93,32 @@ if TYPE_CHECKING:
 TIMEZONES_SET = None
 
 
+def _device_registry_get_or_create(
+    device_registry: dr.DeviceRegistry,
+    *,
+    config_entry_id: str,
+    via_device: tuple[str, str] | None = None,
+    **kwargs,
+):
+    """Create a device entry across Home Assistant versions.
+
+    Home Assistant has started deprecating the ``via_device`` argument in favor
+    of ``via_device_id``. The old argument still works in current releases, but
+    the new API will be required by Home Assistant 2027.8.0.
+    """
+    create = device_registry.async_get_or_create
+    parameters = inspect.signature(create).parameters
+
+    if via_device is not None:
+        if "via_device_id" in parameters:
+            via = device_registry.async_get_device(identifiers={via_device})
+            kwargs["via_device_id"] = via.id if via else None
+        else:
+            kwargs["via_device"] = via_device
+
+    return create(config_entry_id=config_entry_id, **kwargs)
+
+
 class BaseDevice(EntityManager):
     """
     Abstract base class for Device and SubDevice (from hub)
@@ -128,7 +155,8 @@ class BaseDevice(EntityManager):
             **kwargs,
         )
         self.online = False
-        self.device_registry_entry = self.api.device_registry.async_get_or_create(
+        self.device_registry_entry = _device_registry_get_or_create(
+            self.api.device_registry,
             config_entry_id=self.config_entry.entry_id,
             connections=kwargs.get("connections"),
             manufacturer=mc.MANUFACTURER,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -27,3 +27,38 @@ def test_obfuscated_key():
             assert (
                 obfuscate.obfuscated_dict({key: src})[key] == result
             ), f"{key}: {src}"
+
+
+def test_via_device_registry_compatibility():
+    """Verify we keep working with both current and future Home Assistant APIs."""
+    from types import SimpleNamespace
+
+    import custom_components.meross_lan.helpers.device as md
+
+    class LegacyRegistry:
+        def async_get_device(self, identifiers):
+            return SimpleNamespace(id="parent-device-id")
+
+        def async_get_or_create(self, **kwargs):
+            return kwargs
+
+    class NewRegistry:
+        def async_get_device(self, identifiers):
+            return SimpleNamespace(id="parent-device-id")
+
+        def async_get_or_create(self, *, config_entry_id, via_device_id=None, **kwargs):
+            return {"config_entry_id": config_entry_id, "via_device_id": via_device_id}
+
+    legacy_kwargs = md._device_registry_get_or_create(
+        LegacyRegistry(),
+        config_entry_id="entry-1",
+        via_device=("meross_lan", "parent-device"),
+    )
+    assert legacy_kwargs["via_device"] == ("meross_lan", "parent-device")
+
+    new_kwargs = md._device_registry_get_or_create(
+        NewRegistry(),
+        config_entry_id="entry-1",
+        via_device=("meross_lan", "parent-device"),
+    )
+    assert new_kwargs["via_device_id"] == "parent-device-id"


### PR DESCRIPTION
## Summary

This fixes a Home Assistant deprecation warning for the Meross custom integration.

The warning is:

> Detected that custom integration 'meross_lan' calls `device_registry.async_get_or_create` with a `via_device` argument. This will stop working in Home Assistant 2027.8.0, please report it.

This patch keeps compatibility with both the current Home Assistant API and the newer device registry form by using `via_device_id` when it is available and falling back to `via_device` for older versions.

## Changes

- Added a compatibility helper around device registry creation.
- Use `via_device_id` when the Home Assistant API supports it.
- Keep the old `via_device` path for older versions.
- Added a regression test covering both code paths.

## Validation

- Ran `pytest -q tests/test_helpers.py`
- Result: 2 passed

## Note

There is no rush today, but this is a small fix we can offer now to keep the integration working ahead of the 2027.8.0 change.
